### PR TITLE
Constructor Argument is required.

### DIFF
--- a/src/Getopt.php
+++ b/src/Getopt.php
@@ -45,16 +45,16 @@ class Getopt {
      * The argument $options can be either a string in the format accepted by the PHP library
      * function getopt() or an array
      *
-     * @param mixed $options see above
+     * @param mixed $options Array of options, a String, or null
      *
      * @link https://www.gnu.org/s/hello/manual/libc/Getopt.html GNU Getopt manual
      */
-    public function __construct($options) {
+    public function __construct($options = null) {
         if (is_string($options)) {
             $this->optionList = $this->parseOptionString($options);
         } elseif (is_array($options)) {
             $this->optionList = $this->validateOptions($options);
-        } else {
+        } else if ($options != null) {
             throw new InvalidArgumentException("Getopt(): argument must be string or array");
         }
     }


### PR DESCRIPTION
You shouldn't always have to pass an argument to the constructor, specially when using it along side multiple dynamic files.

Like (just an example
- bootrap.php - initializes getopt
- script1_code.php - adds 4 options to bootrap's getopt object
- script2_code.php - adds 5 options to bootrap's getopt object

so, bootstrap might not add any options by default, but still initializes it.

```
$ phpunit GetoptTest.php 
PHPUnit 3.5.15 by Sebastian Bergmann.

............fetching rest as operands
.......fetching rest as operands
.fetching rest as operands
..fetching rest as operands
..fetching rest as operands
....

Time: 0 seconds, Memory: 6.75Mb

OK (28 tests, 67 assertions)
```
