### PR TITLE
Proposal for handling adding options after object has been created.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -57,6 +57,19 @@ Example:
         array('c', 'charlie', Getopt::OPTIONAL_ARGUMENT)
     ));
 
+#### Adding more options after the Getopt object has been created
+
+The method `addOptions()` can be called with the same arguments as `__construct()`, the options that
+get parsed, will be merged with the previous ones. 
+
+    $getopt = new Getopt;
+    $getopt->addOptions('ab:c::')
+    $getopt->addOptions(array(
+        array('a', null, Getopt::NO_ARGUMENT),
+        array(null, 'bravo', Getopt::REQUIRED_ARGUMENT),
+        array('c', 'charlie', Getopt::OPTIONAL_ARGUMENT)
+    ));
+
 ### 2. Invoke the parser
 
 After constructing the Getopt object, a call to `parse()` will evaluate the arguments and store the

--- a/src/Getopt.php
+++ b/src/Getopt.php
@@ -33,7 +33,7 @@ class Getopt {
     const REQUIRED_ARGUMENT = 1;
     const OPTIONAL_ARGUMENT = 2;
 
-    private $optionList;
+    private $optionList = array();
 
     private $options;
 
@@ -50,12 +50,8 @@ class Getopt {
      * @link https://www.gnu.org/s/hello/manual/libc/Getopt.html GNU Getopt manual
      */
     public function __construct($options = null) {
-        if (is_string($options)) {
-            $this->optionList = $this->parseOptionString($options);
-        } elseif (is_array($options)) {
-            $this->optionList = $this->validateOptions($options);
-        } else if ($options != null) {
-            throw new InvalidArgumentException("Getopt(): argument must be string or array");
+        if ($options !== null) {
+            $this->addOptions($options);
         }
     }
 
@@ -305,5 +301,38 @@ class Getopt {
      */
     public function getOptionList() {
         return $this->optionList;
+    }
+
+    /**
+     * Parses and Adds options
+     * The argument $options can be either a string in the format accepted by the PHP library
+     * function getopt() or an array
+     *
+     * @param mixed $options Array of options, a String, or null
+     */
+    public function addOptions($options)
+    {
+        if (is_string($options)) {
+            return $this->addParsedOptions($this->parseOptionString($options));
+        }
+
+        if (is_array($options)) {
+            return $this->addParsedOptions($this->validateOptions($options));
+        }
+        
+        throw new InvalidArgumentException("Getopt(): argument must be string or array");
+    }
+
+    /**
+     * Merges new options with the ones already in the Getopt optionList.
+     * 
+     * @param array $options The array from parsing from parseOptionString() or validateOptions()
+     *
+     * @return array
+     * @internal
+     */
+    private function addParsedOptions (array $options)
+    {
+        return $this->optionList = array_merge($this->optionList, $options);
     }
 }

--- a/test/GetoptTest.php
+++ b/test/GetoptTest.php
@@ -4,7 +4,6 @@ require_once dirname(__FILE__) . '/../src/Getopt.php';
 
 
 class GetoptTest extends PHPUnit_Framework_TestCase {
-    
     public function testConstructorString() {
         $getopt = new Getopt('ab:c::d');
         $opts = $getopt->getOptionList();
@@ -230,5 +229,22 @@ class GetoptTest extends PHPUnit_Framework_TestCase {
         $getopt->parse('-a -b');
         $this->assertEquals(1, $getopt->getOption('a'));
         $this->assertEquals(1, $getopt->getOption('b'));
+    }
+
+    public function testAddOptions ()
+    {
+        $getopt = new Getopt();
+        $getopt->addOptions('a:');
+        $getopt->addOptions(array(
+            array('s', null, Getopt::OPTIONAL_ARGUMENT),
+            array(null, 'long', Getopt::OPTIONAL_ARGUMENT),
+            array('n', 'name', Getopt::OPTIONAL_ARGUMENT)
+        ));
+
+        $getopt->parse('-a aparam -s sparam --long longparam');
+        $this->assertCount(4, $getopt->getOptionList());
+        $this->assertEquals('aparam', $getopt->getOption('a'));
+        $this->assertEquals('longparam', $getopt->getOption('long'));
+        $this->assertEquals('sparam', $getopt->getOption('s'));
     }
 }


### PR DESCRIPTION
This wasn't implemented on the previous pull request - didn't realize you couldn't do.

Basically the constructor did the logc on how to process the arguments and how to parse them. I moved it to a newly created public method `addOptions()` so we can add more options later on.

I added a new test for my changes.

All tests pass

```
PHPUnit 3.5.15 by Sebastian Bergmann.

............fetching rest as operands
.......fetching rest as operands
.fetching rest as operands
..fetching rest as operands
..fetching rest as operands
.....

Time: 0 seconds, Memory: 6.75Mb

OK (29 tests, 71 assertions)
```
