### PR TITLE
Allow to specify script title in help output

### DIFF
--- a/src/Ulrichsg/Getopt.php
+++ b/src/Ulrichsg/Getopt.php
@@ -43,6 +43,8 @@ class Getopt {
     protected $operands = array();
 	/** @var int */
 	protected $defaultType;
+    /** @var string */
+    protected $title = '';
 
     /**
      * Create a new Getopt object.
@@ -203,7 +205,8 @@ class Getopt {
      * @return string help message for given options.
      */
     public function getHelpText($padding = 25) {
-        $help_text = sprintf("Usage: %s [options] [operands]\n", $this->scriptName);
+        $help_text = $this->title ?: '';
+        $help_text .= sprintf("Usage: %s [options] [operands]\n", $this->scriptName);
         $help_text .= "Options:\n";
         foreach ($this->optionList as $name => $option) {
             list($short, $long, $arg, $description) = $option;
@@ -477,5 +480,15 @@ class Getopt {
         }
 
         return preg_split("//u", $str, -1, PREG_SPLIT_NO_EMPTY);
+    }
+
+    /**
+     * Application title in help message.
+     *
+     * @param string $value
+     */
+    public function setTitle($value)
+    {
+        $this->title = $value;
     }
 }

--- a/test/Ulrichsg/GetoptTest.php
+++ b/test/Ulrichsg/GetoptTest.php
@@ -323,6 +323,29 @@ class GetoptTest extends \PHPUnit_Framework_TestCase {
         $getopt->showHelp();
     }
 
+    public function testShowHelpWithTitle()
+    {
+        $getopt = new Getopt(array(
+            array('a', 'alpha', Getopt::NO_ARGUMENT),
+            array(null, 'beta', Getopt::OPTIONAL_ARGUMENT),
+            array('c', null, Getopt::REQUIRED_ARGUMENT)
+        ));
+        $getopt->setTitle("Test version 1.2.0\n");
+        $getopt->parse('');
+
+        $script = $_SERVER['PHP_SELF'];
+
+        $expected = "Test version 1.2.0\n";
+        $expected .= "Usage: $script [options] [operands]\n";
+        $expected .= "Options:\n";
+        $expected .= "  -a, --alpha             \n";
+        $expected .= "  --beta [<arg>]          \n";
+        $expected .= "  -c <arg>                \n";
+
+        $this->expectOutputString($expected);
+        $getopt->showHelp();
+    }
+
     public function testDoubleHyphenNotInOperands()
     {
         $getopt = new Getopt('a:');


### PR DESCRIPTION
Using getopt-php in console applications you're often want to specify application help text title. 
Sample application titles:
- PHPUnit 3.8.2 by Sebastian Bergmann.
- top: procps version 3.2.8
- MyApp 1.0.0
