### PR TITLE
- Require long options to be at least 2 chars long, only allow alphanume...

### DIFF
--- a/src/Ulrichsg/Getopt.php
+++ b/src/Ulrichsg/Getopt.php
@@ -24,8 +24,8 @@ namespace Ulrichsg;
  * Getopt.PHP allows for easy processing of command-line arguments.
  * It is a more powerful, object-oriented alternative to PHP's built-in getopt() function.
  *
- * @version 1.3.0
- * @version 2013-12-11
+ * @version 1.5.0
+ * @version 2013-12-13
  * @link    https://github.com/ulrichsg/getopt-php
  */
 class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate {
@@ -60,14 +60,26 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate {
      * function getopt() or an array
      *
      * @param mixed $options Array of options, a String, or null
-	 * @param int $defaultType The default option type to use when omitted
+	   * @param int $defaultType The default option type to use when omitted
+	   * @param bool $allowDuplicates When false, throws an exception if any duplicate short/long options are found; when true, allows duplicate options.
      *
      * @link https://www.gnu.org/s/hello/manual/libc/Getopt.html GNU Getopt manual
      */
-    public function __construct($options = null, $defaultType = Getopt::NO_ARGUMENT) {
+    public function __construct($options = null, $defaultType = Getopt::NO_ARGUMENT, $allowDuplicates = false) {
 		$this->defaultType = $defaultType;
         if ($options !== null) {
             $this->addOptions($options);
+            
+            //now check the optionList for duplicates, starting at the bottom (last added -> first added)
+            if (!$allowDuplicates)
+              foreach(array_reverse( $this->optionList, true) as $idx=>$opt) {
+                $short = $opt[self::OPT_SHORT];
+                $long = $opt[self::OPT_LONG];
+                if (( $this->checkForDuplicateOption($short, $idx))||
+                    ($long = $this->checkForDuplicateOption($long, $idx))) {
+                  throw new \InvalidArgumentException("Duplicate option found: [Index($idx)] '$short' or '$long' already exists in available options");
+                }
+              }
         }
     }
 
@@ -344,7 +356,7 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate {
                 throw new \InvalidArgumentException("First component of option must be "
                         . "null or a letter, found '" . $option[self::OPT_SHORT] . "'");
             }
-            if (!(is_null($option[self::OPT_LONG]) || preg_match("/^[a-zA-Z0-9_-]*$/", $option[self::OPT_LONG]))) {
+            if (!(is_null($option[self::OPT_LONG]) || preg_match("/^[a-zA-Z0-9][a-zA-Z0-9_-]{1,}$/", $option[self::OPT_LONG]))) {
                 throw new \InvalidArgumentException("Second component of option must be "
                         . "null or an alphanumeric string, found '" . $option[self::OPT_LONG] . "'");
             }
@@ -358,6 +370,10 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate {
             if (!isset($option[self::OPT_DESC])) {
                 $option[self::OPT_DESC] = ""; // description
             }
+            /*if (($this->checkForDuplicateOption($option[self::OPT_SHORT]))||
+                ($this->checkForDuplicateOption($option[self::OPT_LONG]))) {
+              throw new \InvalidArgumentException("That option already exists in available options");
+            }*/
         }
         return $options;
     }
@@ -399,6 +415,27 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate {
             }
         }
         throw new \UnexpectedValueException("Option '$option' is unknown");
+    }
+    
+  /**
+   * Check for duplicate short/long option names
+   *
+   * @return boolean
+   * @internal
+   */
+    protected function checkForDuplicateOption($optionstr, $index) {
+      echo count($this->optionList);
+      echo "[DBG] checkForDuplicateOption:: optionstr = $optionstr \n";
+      $n = 0;
+      foreach($this->optionList as $idx=>$opt) {
+        echo "  $idx = $idx; short=".$opt[self::OPT_SHORT]."; long=".$opt[self::OPT_LONG]."; \n";
+        if (is_string($optionstr) && $idx != $index)
+          if (($optionstr == $opt[self::OPT_SHORT]) ||
+              ($optionstr == $opt[self::OPT_LONG]))
+            return true;
+          $n++;
+        }
+      return false;
     }
 
 	/**


### PR DESCRIPTION
- Require long options to be at least 2 chars long, only allow alphanumeric as first char (don't allow dash/underscore as first char)
- Check for duplicate short/long options and throw InvalidArgumentException if a duplicate is found
- Duplicate option checking is only done if the $allowDuplicates param in __construct is set to FALSE (default)
- Updated @version phpdoc tags (version & modified date)
