### PR TITLE
Fixed an issue with the composer psr-0 autload setup.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Ulrichsg": "src"
+            "Ulrichsg\\": "src"
         }
     }
 }


### PR DESCRIPTION
Had an issues with autoloading the Getopt class and identified the composer autoloading settings to be the problem. As soon as backslashes was added to the "Ulrichsg" namespace (similar to the other entries in the autoloader file) it started working.

According to https://getcomposer.org/doc/04-schema.md#psr-0 the namespace declaration should end in backspaces.
