### PR TITLE
Added fluent-style static constructor helper

### DIFF
--- a/src/Ulrichsg/Getopt/Option.php
+++ b/src/Ulrichsg/Getopt/Option.php
@@ -84,15 +84,6 @@ class Option
         $this->argument = $arg;
         return $this;
     }
-    
-    /**
-     * Fluent interface for constructor so options can be added during construction
-     * @see Options::__construct()
-     */
-    public static function create($short, $long, $mode = Getopt::NO_ARGUMENT)
-    {
-    	return new self($short, $long, $mode);
-    }
 
     /**
      * Returns true if the given string is equal to either the short or the long name.
@@ -133,6 +124,15 @@ class Option
     public function getArgument()
     {
         return $this->argument;
+    }
+    
+    /**
+     * Fluent interface for constructor so options can be added during construction
+     * @see Options::__construct()
+     */
+    public static function create($short, $long, $mode = Getopt::NO_ARGUMENT)
+    {
+    	return new self($short, $long, $mode);
     }
 
     private function setShort($short)


### PR DESCRIPTION
Instantiating a new option and setting its properties in one step is currently not possible for most versions of PHP, since you can't put `->` after constructing an object via `new ...`.  This means that `new Option('a', null)->setDefaultValue(10)` will not work.

Here's the nasty mess I had to use for my application:

```
$options = array();

$opt = new Option('s', 'strict', Getopt::REQUIRED_ARGUMENT);
$options[] = $opt->setDescription('Use strict comparison of capability values')
    ->setDefaultValue('true')
    ->setValidation(function($value) {
        return in_array($value, array('true', 'false'));
    });

$opt = new Option('d', 'details', Getopt::REQUIRED_ARGUMENT);
$options[] = $opt->setDescription('Include lists of all devices and capabilities instead of just the counts')
    ->setDefaultValue('false')
    ->setValidation(function($value) {
        return in_array($value, array('true', 'false'));
    });

$getopt = new Getopt($options);
```

To improve things, I've added a public static function `create()` which constructs a new `Option` object and returns it.  This lets me improve my syntax as follows:

```
$getopt = new Getopt(array(
    Option::create('s', 'strict', Getopt::REQUIRED_ARGUMENT)
        ->setDescription('Use strict comparison of capability values')
        ->setDefaultValue('true')
        ->setValidation(function($value) {
            return in_array($value, array('true', 'false'));
        }),

    Option::create('d', 'details', Getopt::REQUIRED_ARGUMENT)
        ->setDescription('Include lists of all devices and capabilities instead of just the counts')
        ->setDefaultValue('false')
        ->setValidation(function($value) {
            return in_array($value, array('true', 'false'));
        }),
));
```
