### PR TITLE
helptext: add support for custom banner message

### DIFF
--- a/src/Ulrichsg/Getopt/Getopt.php
+++ b/src/Ulrichsg/Getopt/Getopt.php
@@ -26,6 +26,8 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
     private $options = array();
     /** @var array */
     private $operands = array();
+    /** @var string */
+    private $banner =  "Usage: %s [options] [operands]\n";
 
     /**
      * Creates a new Getopt object.
@@ -185,13 +187,36 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
     }
 
     /**
+     * Returns the banner string
+     *
+     * @return string
+     */
+    public function getBanner()
+    {
+        return $this->banner;
+    }
+
+    /**
+     * Set the banner string
+     *
+     * @param string $banner    The banner string; will be passed to sprintf(), can include %s for current scripts name.
+     *                          Be sure to include a trailing line feed.
+     * @return Getopt
+     */
+    public function setBanner($banner)
+    {
+        $this->banner = $banner;
+        return $this;
+    }
+
+    /**
      * Returns an usage information text generated from the given options.
      * @param int $padding Number of characters to pad output of options to
      * @return string
      */
     public function getHelpText($padding = 25)
     {
-        $helpText = sprintf("Usage: %s [options] [operands]\n", $this->scriptName);
+        $helpText = sprintf($this->getBanner(), $this->scriptName);
         $helpText .= "Options:\n";
         foreach ($this->optionList as $option) {
             $mode = '';

--- a/test/Ulrichsg/Getopt/GetoptTest.php
+++ b/test/Ulrichsg/Getopt/GetoptTest.php
@@ -177,4 +177,23 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $getopt->getHelpText());
     }
+
+    public function testHelpTextNoParse()
+    {
+        $getopt = new Getopt();
+        $expected = "Usage:  [options] [operands]\nOptions:\n";
+        $this->assertSame($expected, $getopt->getHelpText());
+    }
+
+    public function testHelpTextWithCustomBanner()
+    {
+        $script = $_SERVER['PHP_SELF'];
+        
+        $getopt = new Getopt();
+        $getopt->setBanner("My custom Banner %s\n");
+        $this->assertSame("My custom Banner \nOptions:\n", $getopt->getHelpText());
+
+        $getopt->parse();
+        $this->assertSame("My custom Banner $script\nOptions:\n", $getopt->getHelpText());
+    }
 }


### PR DESCRIPTION
This adds the methods `setBanner()` and `getBanner()` to allow customization of the banner message itself.

Example scenario: I write an application which accepts an arbitrary number of files ("operands" in your terms) but it's hard to properly convey to this user. The would allow me to change the message e.g. to:
`Usage: myscript [options] [operands]` to
`Usage: myscript [options] <files...>`
etc.
