### PR TITLE
[RFC] Add GNU getopt "interleaved options" mode

### DIFF
--- a/src/Ulrichsg/Getopt/CommandLineParser.php
+++ b/src/Ulrichsg/Getopt/CommandLineParser.php
@@ -40,11 +40,14 @@ class CommandLineParser
             if (empty($arg)) {
                 continue;
             }
-            if ($arg == '--' || mb_substr($arg, 0, 1) != '-') {
+            if ($arg == '--') {
                 // no more options, treat the remaining arguments as operands
-                $firstOperandIndex = ($arg == '--') ? $i + 1 : $i;
-                $operands = array_slice($arguments, $firstOperandIndex);
+                $firstOperandIndex = $i + 1;
+                $operands = array_merge($operands, array_slice($arguments, $firstOperandIndex));
                 break;
+            } else if (mb_substr($arg, 0, 1) != '-') {
+                $operands[] = $arg;
+                continue;
             }
             if (mb_substr($arg, 0, 2) == '--') {
                 $this->addLongOption($arguments, $i);

--- a/test/Ulrichsg/Getopt/CommandLineParserTest.php
+++ b/test/Ulrichsg/Getopt/CommandLineParserTest.php
@@ -276,6 +276,27 @@ class CommandLineParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('baz', $operands[2]);
     }
 
+    public function testInterleavedArgumentsAndOperands()
+    {
+        $parser = new CommandLineParser(array(
+            new Option('a', null, Getopt::REQUIRED_ARGUMENT),
+            new Option('b', null, Getopt::REQUIRED_ARGUMENT),
+            new Option('c', null, Getopt::REQUIRED_ARGUMENT)
+        ));
+        $parser->parse('-a 0 foo -b 1 bar baz foobar -c 3');
+
+        $options = $parser->getOptions();
+        $this->assertEquals('0', $options['a']);
+        $this->assertEquals('1', $options['b']);
+        $this->assertEquals('3', $options['c']);
+        $operands = $parser->getOperands();
+        $this->assertCount(4, $operands);
+        $this->assertEquals('foo', $operands[0]);
+        $this->assertEquals('bar', $operands[1]);
+        $this->assertEquals('baz', $operands[2]);
+        $this->assertEquals('foobar', $operands[3]);
+    }
+
     public function testParseWithArgumentValidation()
     {
         $validation = 'is_numeric';


### PR DESCRIPTION
Here is a set of commits which change the parsing from POSIX style (stop at the first non-argument or -- ) to GNU getopt style (interleaved options and operands).

I am not sure which is wanted. I know I prefer the GNU style (it's very useful for things like ./mytool -a opt1 -b opt2 operand1 operand2 -h, that is adding --help at the end as you are building your command-line string) , but maybe others prefer the POSIX style.

This will probably require some form of parsing-style option which I haven't implemented (yet).
