### PR TITLE
Add Getopt::getKnownOptions()

### DIFF
--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PublishConfigData" serverName="halo-www" />
+</project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.3.0 (2015-03-28)
+
+Features:
+* Optional argument descriptions (courtesy of @sabl0r)
+
+Bugfixes:
+* Passing a single hyphen as an option value works now (courtesy of @tistre)
+
+
 ## 2.2.0 (2014-09-13)
 
 Features:

--- a/src/Ulrichsg/Getopt/CommandLineParser.php
+++ b/src/Ulrichsg/Getopt/CommandLineParser.php
@@ -171,12 +171,22 @@ class CommandLineParser
                 }
                 // for optional-argument options, set value to 1 if none was given
                 $value = (mb_strlen($value) > 0) ? $value : 1;
-                // add both long and short names (if they exist) to the option array to facilitate lookup
-                if ($option->short()) {
+                // for GetOpt::MULTIPLE_ARGUMENT, retain all arguments in an array
+                if($option->multipleArgument()) {
+                  if ($option->short()) {
+                    $this->options[$option->short()][] = $value;
+                  }
+                  if ($option->long()) {
+                    $this->options[$option->long()][] = $value;
+                  }
+                } else {
+                  // add both long and short names (if they exist) to the option array to facilitate lookup
+                  if ($option->short()) {
                     $this->options[$option->short()] = $value;
-                }
-                if ($option->long()) {
+                  }
+                  if ($option->long()) {
                     $this->options[$option->long()] = $value;
+                  }
                 }
                 return;
             }

--- a/src/Ulrichsg/Getopt/Getopt.php
+++ b/src/Ulrichsg/Getopt/Getopt.php
@@ -223,9 +223,10 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
     /**
      * Returns an usage information text generated from the given options.
      * @param int $padding Number of characters to pad output of options to
+     * @param int $terminalCols If provided, option descriptions will wrap to fit the given width terminal.
      * @return string
      */
-    public function getHelpText($padding = 25)
+    public function getHelpText($padding = 25, $terminalCols = NULL)
     {
         $helpText = sprintf($this->getBanner(), $this->scriptName);
         $helpText .= "Options:\n";
@@ -250,7 +251,12 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
                 $options = $short ? : $long;
             }
             $padded = str_pad(sprintf("  %s %s", $options, $mode), $padding);
-            $helpText .= sprintf("%s %s\n", $padded, $option->getDescription());
+            $desc = $option->getDescription();
+            if ($terminalCols && is_numeric($terminalCols) && $terminalCols > $padding) {
+                $wrapBreak = sprintf('%-' . ($padding + 2) . 's', "\n");
+                $desc = wordwrap($desc, $terminalCols - $padding - 1, $wrapBreak);
+            }
+            $helpText .= sprintf("%s %s\n", $padded, $desc);
         }
         return $helpText;
     }

--- a/src/Ulrichsg/Getopt/Getopt.php
+++ b/src/Ulrichsg/Getopt/Getopt.php
@@ -165,11 +165,11 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
     {
         return $this->options;
     }
-    
+
     /**
      * Returns the list of known Options. Useful for introspection over Getopt instances;
      * retreive actual option values with {@link getOptions()}.
-     * 
+     *
      * @return Option[] Array of all Option objects that have been added.
      */
     public function getKnownOptions() {

--- a/src/Ulrichsg/Getopt/Getopt.php
+++ b/src/Ulrichsg/Getopt/Getopt.php
@@ -15,6 +15,7 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
     const NO_ARGUMENT = 0;
     const REQUIRED_ARGUMENT = 1;
     const OPTIONAL_ARGUMENT = 2;
+    const MULTIPLE_ARGUMENT = 4;
 
     /** @var OptionParser */
     private $optionParser;

--- a/src/Ulrichsg/Getopt/Option.php
+++ b/src/Ulrichsg/Getopt/Option.php
@@ -108,7 +108,12 @@ class Option
 
     public function mode()
     {
-        return $this->mode;
+      return $this->mode & (Getopt::REQUIRED_ARGUMENT | Getopt::OPTIONAL_ARGUMENT);
+    }
+    
+    public function multipleArgument()
+    {
+      return $this->mode & Getopt::MULTIPLE_ARGUMENT;
     }
 
     public function getDescription()
@@ -153,9 +158,11 @@ class Option
 
     private function setMode($mode)
     {
-        if (!in_array($mode, array(Getopt::NO_ARGUMENT, Getopt::OPTIONAL_ARGUMENT, Getopt::REQUIRED_ARGUMENT), true)) {
-            throw new \InvalidArgumentException("Option mode must be one of "
-                ."Getopt::NO_ARGUMENT, Getopt::OPTIONAL_ARGUMENT and Getopt::REQUIRED_ARGUMENT");
+        $valid_modes = array(Getopt::NO_ARGUMENT, Getopt::OPTIONAL_ARGUMENT, Getopt::REQUIRED_ARGUMENT, 
+            Getopt::OPTIONAL_ARGUMENT | GetOpt::MULTIPLE_ARGUMENT, GetOpt::REQUIRED_ARGUMENT | GetOpt::MULTIPLE_ARGUMENT);
+        if (!in_array($mode, $valid_modes, true)) {
+            throw new \InvalidArgumentException("Option mode must be Getopt::OPTIONAL_ARGUMENT or Getopt::REQUIRED_ARGUMENT"
+                ."optinally bitwise-ORed with GetOpt::MULTIPLE_ARGUMENT, or Getopt::NO_ARGUMENT.");
         }
         $this->mode = $mode;
     }

--- a/test/Ulrichsg/Getopt/CommandLineParserTest.php
+++ b/test/Ulrichsg/Getopt/CommandLineParserTest.php
@@ -359,4 +359,16 @@ class CommandLineParserTest extends \PHPUnit_Framework_TestCase
         $parser = new CommandLineParser(array($option));
         $parser->parse('-a nonnumeric');
     }
+    
+    public function testParseMultipleArgument() 
+    {
+      $parser = new CommandLineParser(array(
+          new Option('a', null, Getopt::REQUIRED_ARGUMENT | Getopt::MULTIPLE_ARGUMENT)
+      ));
+      $parser->parse('-a str1 -a str2');
+      $options = $parser->getOptions();
+      $this->assertCount(2, $options['a']);
+      $this->assertSame('str1', $options['a'][0]);
+      $this->assertSame('str2', $options['a'][1]);
+    }
 }

--- a/test/Ulrichsg/Getopt/OptionTest.php
+++ b/test/Ulrichsg/Getopt/OptionTest.php
@@ -41,6 +41,12 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException');
         new Option(null, 'a', Getopt::REQUIRED_ARGUMENT);
     }
+    
+    public function testConstructMultipleNoArgument()
+    {
+      $this->setExpectedException('InvalidArgumentException');
+      new Option('a', null, Getopt::NO_ARGUMENT | Getopt::MULTIPLE_ARGUMENT);
+    }
 
     public function testSetArgument()
     {


### PR DESCRIPTION
Prompted by a script I'm doing that scans a subdirectory for "plugins," which are passed a Getopt instance and have the opportunity to add options before parsing occurs. There didn't seem to be a way to see if any of my plugins added Options.
