### PR TITLE
Support collecting all values of valued arguments 

### DIFF
--- a/src/Ulrichsg/Getopt/CommandLineParser.php
+++ b/src/Ulrichsg/Getopt/CommandLineParser.php
@@ -171,12 +171,22 @@ class CommandLineParser
                 }
                 // for optional-argument options, set value to 1 if none was given
                 $value = (mb_strlen($value) > 0) ? $value : 1;
-                // add both long and short names (if they exist) to the option array to facilitate lookup
-                if ($option->short()) {
+                // for GetOpt::MULTIPLE_ARGUMENT, retain all arguments in an array
+                if($option->multipleArgument()) {
+                  if ($option->short()) {
+                    $this->options[$option->short()][] = $value;
+                  }
+                  if ($option->long()) {
+                    $this->options[$option->long()][] = $value;
+                  }
+                } else {
+                  // add both long and short names (if they exist) to the option array to facilitate lookup
+                  if ($option->short()) {
                     $this->options[$option->short()] = $value;
-                }
-                if ($option->long()) {
+                  }
+                  if ($option->long()) {
                     $this->options[$option->long()] = $value;
+                  }
                 }
                 return;
             }

--- a/src/Ulrichsg/Getopt/Getopt.php
+++ b/src/Ulrichsg/Getopt/Getopt.php
@@ -15,6 +15,7 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
     const NO_ARGUMENT = 0;
     const REQUIRED_ARGUMENT = 1;
     const OPTIONAL_ARGUMENT = 2;
+    const MULTIPLE_ARGUMENT = 4;
 
     /** @var OptionParser */
     private $optionParser;

--- a/src/Ulrichsg/Getopt/Option.php
+++ b/src/Ulrichsg/Getopt/Option.php
@@ -108,7 +108,12 @@ class Option
 
     public function mode()
     {
-        return $this->mode;
+      return $this->mode & (Getopt::REQUIRED_ARGUMENT | Getopt::OPTIONAL_ARGUMENT);
+    }
+    
+    public function multipleArgument()
+    {
+      return $this->mode & Getopt::MULTIPLE_ARGUMENT;
     }
 
     public function getDescription()
@@ -153,9 +158,11 @@ class Option
 
     private function setMode($mode)
     {
-        if (!in_array($mode, array(Getopt::NO_ARGUMENT, Getopt::OPTIONAL_ARGUMENT, Getopt::REQUIRED_ARGUMENT), true)) {
-            throw new \InvalidArgumentException("Option mode must be one of "
-                ."Getopt::NO_ARGUMENT, Getopt::OPTIONAL_ARGUMENT and Getopt::REQUIRED_ARGUMENT");
+        $valid_modes = array(Getopt::NO_ARGUMENT, Getopt::OPTIONAL_ARGUMENT, Getopt::REQUIRED_ARGUMENT, 
+            Getopt::OPTIONAL_ARGUMENT | GetOpt::MULTIPLE_ARGUMENT, GetOpt::REQUIRED_ARGUMENT | GetOpt::MULTIPLE_ARGUMENT);
+        if (!in_array($mode, $valid_modes, true)) {
+            throw new \InvalidArgumentException("Option mode must be Getopt::OPTIONAL_ARGUMENT or Getopt::REQUIRED_ARGUMENT"
+                ."optinally bitwise-ORed with GetOpt::MULTIPLE_ARGUMENT, or Getopt::NO_ARGUMENT.");
         }
         $this->mode = $mode;
     }

--- a/test/Ulrichsg/Getopt/CommandLineParserTest.php
+++ b/test/Ulrichsg/Getopt/CommandLineParserTest.php
@@ -359,4 +359,16 @@ class CommandLineParserTest extends \PHPUnit_Framework_TestCase
         $parser = new CommandLineParser(array($option));
         $parser->parse('-a nonnumeric');
     }
+    
+    public function testParseMultipleArgument() 
+    {
+      $parser = new CommandLineParser(array(
+          new Option('a', null, Getopt::REQUIRED_ARGUMENT | Getopt::MULTIPLE_ARGUMENT)
+      ));
+      $parser->parse('-a str1 -a str2');
+      $options = $parser->getOptions();
+      $this->assertCount(2, $options['a']);
+      $this->assertSame('str1', $options['a'][0]);
+      $this->assertSame('str2', $options['a'][1]);
+    }
 }

--- a/test/Ulrichsg/Getopt/OptionTest.php
+++ b/test/Ulrichsg/Getopt/OptionTest.php
@@ -41,6 +41,12 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException');
         new Option(null, 'a', Getopt::REQUIRED_ARGUMENT);
     }
+    
+    public function testConstructMultipleNoArgument()
+    {
+      $this->setExpectedException('InvalidArgumentException');
+      new Option('a', null, Getopt::NO_ARGUMENT | Getopt::MULTIPLE_ARGUMENT);
+    }
 
     public function testSetArgument()
     {


### PR DESCRIPTION
Support collecting all values of valued arguments when they are specified multiple times.

So, you can make a new Option('a', null, GetOpt::REQUIRED_ARGUMENT | GetOpt::MULTIPLE_ARGUMENT). Then for 

./my-script.php -a str1 -a str2

the option value for option a is an array containing all values that were provided.
