### PR TITLE
Test for the presence of a default argument value with is_null().

### DIFF
--- a/src/Ulrichsg/Getopt/Argument.php
+++ b/src/Ulrichsg/Getopt/Argument.php
@@ -13,7 +13,7 @@ class Argument
 
     /**
      * Creates a new argument.
-     * 
+     *
      * @param scalar|null $default Default value or NULL
      * @param callable|null $validation a validation function (optional)
      * @throws \InvalidArgumentException
@@ -31,7 +31,7 @@ class Argument
 
     /**
      * Set the default value
-     * 
+     *
      * @param scalar $value
      * @return Argument this object (for chaining calls)
      * @throws \InvalidArgumentException
@@ -48,7 +48,7 @@ class Argument
     /**
      * Set a validation function.
      * The function must take a string and return true if it is valid, false otherwise.
-     * 
+     *
      * @param callable $callable
      * @return Argument this object (for chaining calls)
      * @throws \InvalidArgumentException
@@ -64,7 +64,7 @@ class Argument
 
     /**
      * Check if an argument validates according to the specification.
-     * 
+     *
      * @param string $arg
      * @return bool
      */
@@ -75,7 +75,7 @@ class Argument
 
     /**
      * Check if the argument has a validation function
-     * 
+     *
      * @return bool
      */
     public function hasValidation()
@@ -85,17 +85,17 @@ class Argument
 
     /**
      * Check whether the argument has a default value
-     * 
+     *
      * @return boolean
      */
     public function hasDefaultValue()
     {
-        return !empty($this->default);
+        return !is_null($this->default);
     }
 
     /**
      * Retrieve the default value
-     * 
+     *
      * @return scalar|null
      */
     public function getDefaultValue()


### PR DESCRIPTION
Test for the presence of a default argument value with is_null() rather than empty().

This allows users to supply a default value of 0 (zero), which would otherwise be considered "empty."
