### PR TITLE
Allow wrapping option descriptions

### DIFF
--- a/src/Ulrichsg/Getopt/Getopt.php
+++ b/src/Ulrichsg/Getopt/Getopt.php
@@ -212,9 +212,10 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
     /**
      * Returns an usage information text generated from the given options.
      * @param int $padding Number of characters to pad output of options to
+     * @param int $terminalCols If provided, option descriptions will wrap to fit the given width terminal.
      * @return string
      */
-    public function getHelpText($padding = 25)
+    public function getHelpText($padding = 25, $terminalCols = NULL)
     {
         $helpText = sprintf($this->getBanner(), $this->scriptName);
         $helpText .= "Options:\n";
@@ -239,7 +240,12 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
                 $options = $short ? : $long;
             }
             $padded = str_pad(sprintf("  %s %s", $options, $mode), $padding);
-            $helpText .= sprintf("%s %s\n", $padded, $option->getDescription());
+            $desc = $option->getDescription();
+            if ($terminalCols && is_numeric($terminalCols) && $terminalCols > $padding) {
+                $wrapBreak = sprintf('%-' . ($padding + 2) . 's', "\n");
+                $desc = wordwrap($desc, $terminalCols - $padding - 1, $wrapBreak);
+            }
+            $helpText .= sprintf("%s %s\n", $padded, $desc);
         }
         return $helpText;
     }


### PR DESCRIPTION
Enables much cleaner formatting of option descriptions that are too long to fit on one line of the terminal by explicitly wrapping them and padding new lines of the description such that all lines of the option descriptions are equally indented.

Requires that the terminal width be determined externally and provided as a parameter.
