### PR TITLE
PHP warning in Getopt->parse()

### DIFF
--- a/src/Ulrichsg/Getopt/Getopt.php
+++ b/src/Ulrichsg/Getopt/Getopt.php
@@ -123,7 +123,13 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
         if (!isset($arguments)) {
             global $argv;
             $arguments = $argv;
-            $this->scriptName = array_shift($arguments); // $argv[0] is the script's name
+            // $argv can be null, e.g. when running from web server or when
+            // register_argc_argv is disabled
+            if($arguments === null) {
+                $this->scriptName = $_SERVER['PHP_SELF'];
+            } else {
+                $this->scriptName = array_shift($arguments); // $argv[0] is the script's name
+            }
         } elseif (is_string($arguments)) {
             $this->scriptName = $_SERVER['PHP_SELF'];
             $arguments = explode(' ', $arguments);


### PR DESCRIPTION
I ran a command-line script from my web server, and got the following (version 2.3.0, installed via composer):

```
Warning: array_shift() expects parameter 1 to be array, null given in /path/to/vendor/ulrichsg/getopt-php/src/Ulrichsg/Getopt/Getopt.php on line 126

Call Stack:
    0.0014     237920   1. {main}() /path/to/script.php:0
    0.0123     324888   2. Ulrichsg\Getopt\Getopt->parse() /path/to/script.php:33
    0.0124     325256   3. array_shift() /path/to/vendor/ulrichsg/getopt-php/src/Ulrichsg/Getopt/Getopt.php:126
```

_$argv_ can be null, e.g. when running from web server or when register_argc_argv is disabled, so don't call array_shift() if it is.
