### PR TITLE
Fixed Getopt::parse() fails to handle array argument

### DIFF
--- a/src/Ulrichsg/Getopt/Getopt.php
+++ b/src/Ulrichsg/Getopt/Getopt.php
@@ -123,6 +123,8 @@ class Getopt implements \Countable, \ArrayAccess, \IteratorAggregate
         if (!isset($arguments)) {
             global $argv;
             $arguments = $argv;
+        }
+        if (is_array($arguments)) {
             $this->scriptName = array_shift($arguments); // $argv[0] is the script's name
         } elseif (is_string($arguments)) {
             $this->scriptName = $_SERVER['PHP_SELF'];

--- a/test/Ulrichsg/Getopt/GetoptTest.php
+++ b/test/Ulrichsg/Getopt/GetoptTest.php
@@ -95,6 +95,13 @@ class GetoptTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $getopt->getOption('a'));
     }
 
+    public function testParseWithArrayArgument()
+    {
+        $getopt = new Getopt('a');
+        $getopt->parse(array('foo.php', '-a'));
+        $this->assertEquals(1, $getopt->getOption('a'));
+    }
+
     public function testAccessMethods()
     {
         $getopt = new Getopt('a');


### PR DESCRIPTION
When parse() was called with an explicit array argument, it failed to pick the script name from arguments, then the whole arguments were parsed as operands.
For example, $getopt->parse(['foo.php', '-a']) results in:
- scriptName: null
- operands: ["foo.php", "-a"]
- options: []