### PR TITLE
Feature gnu compatibility

### DIFF
--- a/src/CommandLineParser.php
+++ b/src/CommandLineParser.php
@@ -33,17 +33,23 @@ class CommandLineParser
         if (!is_array($arguments)) {
             $arguments = $this->parseArgumentString($arguments);
         }
-        $operands = array();
+        $operands = &$this->operands;
         $numArgs = count($arguments);
         for ($i = 0; $i < $numArgs; ++$i) {
             $arg = $arguments[$i];
 
-            if (($arg === '--') || ($arg === '-') || (mb_substr($arg, 0, 1) !== '-')) {
-                // no more options, treat the remaining arguments as operands
-                $firstOperandIndex = ($arg == '--') ? $i + 1 : $i;
-                $operands = array_slice($arguments, $firstOperandIndex);
+            if ($arg === '--') {
+                // the rest are operands
+                $operands = array_merge($operands, array_slice($arguments, $i + 1));
                 break;
             }
+
+            if (empty($arg) || $arg === '-' || $arg[0] !== '-') {
+                // this is an operand
+                $operands[] = $arg;
+                continue;
+            }
+
             if (mb_substr($arg, 0, 2) == '--') {
                 $this->addLongOption($arguments, $i);
             } else {
@@ -52,13 +58,6 @@ class CommandLineParser
         } // endfor
 
         $this->addDefaultValues();
-
-        // remove '--' from operands array
-        foreach ($operands as $operand) {
-            if ($operand !== '--') {
-                $this->operands[] = $operand;
-            }
-        }
     }
 
     /**

--- a/src/CommandLineParser.php
+++ b/src/CommandLineParser.php
@@ -36,10 +36,8 @@ class CommandLineParser
         $operands = array();
         $numArgs = count($arguments);
         for ($i = 0; $i < $numArgs; ++$i) {
-            $arg = trim($arguments[$i]);
-            if (empty($arg)) {
-                continue;
-            }
+            $arg = $arguments[$i];
+
             if (($arg === '--') || ($arg === '-') || (mb_substr($arg, 0, 1) !== '-')) {
                 // no more options, treat the remaining arguments as operands
                 $firstOperandIndex = ($arg == '--') ? $i + 1 : $i;
@@ -156,7 +154,7 @@ class CommandLineParser
     {
         foreach ($this->optionList as $option) {
             if ($option->matches($string)) {
-                if ($option->mode() == Getopt::REQUIRED_ARGUMENT && !mb_strlen($value)) {
+                if ($option->mode() == Getopt::REQUIRED_ARGUMENT && $value === null) {
                     throw new \UnexpectedValueException("Option '$string' must have a value");
                 }
                 if ($option->getArgument()->hasValidation()) {
@@ -170,7 +168,7 @@ class CommandLineParser
                     $value = is_null($oldValue) ? 1 : $oldValue + 1;
                 }
                 // for optional-argument options, set value to 1 if none was given
-                $value = (mb_strlen($value) > 0) ? $value : 1;
+                $value = $value !== null ? $value : 1;
                 // add both long and short names (if they exist) to the option array to facilitate lookup
                 if ($option->short()) {
                     $this->options[$option->short()] = $value;

--- a/test/CommandLineParserTest.php
+++ b/test/CommandLineParserTest.php
@@ -332,6 +332,22 @@ class CommandLineParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('-', $operands[0]);
     }
 
+    public function testOptionsAfterOperands()
+    {
+        $parser = new CommandLineParser(array(
+            new Option('a', null, Getopt::REQUIRED_ARGUMENT),
+            new Option('b', null, Getopt::REQUIRED_ARGUMENT)
+        ));
+
+        $parser->parse('-a 42 operand -b "don\'t panic"');
+
+        $this->assertEquals(array(
+            'a' => 42,
+            'b' => 'don\'t panic'
+        ), $parser->getOptions());
+        $this->assertEquals(array('operand'), $parser->getOperands());
+    }
+
     public function testEmptyOperandsAndOptionsWithString()
     {
         $parser = new CommandLineParser(array(

--- a/test/CommandLineParserTest.php
+++ b/test/CommandLineParserTest.php
@@ -332,6 +332,44 @@ class CommandLineParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('-', $operands[0]);
     }
 
+    public function testEmptyOperandsAndOptionsWithString()
+    {
+        $parser = new CommandLineParser(array(
+            new Option('a', null, Getopt::REQUIRED_ARGUMENT)
+        ));
+
+        $parser->parse('-a "" ""');
+
+        $this->assertSame(array('a' => ''), $parser->getOptions());
+        $this->assertSame(array(''), $parser->getOperands());
+    }
+
+    public function testEmptyOperandsAndOptionsWithArray()
+    {
+        $parser = new CommandLineParser(array(
+            new Option('a', null, Getopt::REQUIRED_ARGUMENT)
+        ));
+
+        // this is how we get it in $_SERVER['argv']
+        $parser->parse(array(
+            '-a',
+            '',
+            ''
+        ));
+
+        $this->assertSame(array('a' => ''), $parser->getOptions());
+        $this->assertSame(array(''), $parser->getOperands());
+    }
+
+    public function testSpaceOperand()
+    {
+        $parser = new CommandLineParser(array());
+
+        $parser->parse('" "');
+
+        $this->assertSame(array(' '), $parser->getOperands());
+    }
+
     public function testParseWithArgumentValidation()
     {
         $validation = 'is_numeric';


### PR DESCRIPTION
With the gnu compatibility it is now possible to have

- empty string operands `php app.php ""`
- empty string options `php app.php -a ""`
- spaces in front of operands beginning with a hypen or double hypen `php app.php " --" " -"`
- options after operands `php app.php command -q`

This also brings a breaking change. Before every option after an operand was used as operand. In the example above this means that `-q` was an operand. This operand is now an option and therefore the parser checks that there is an option `q` - if not it throws an `UnexpectedValueException`.

This will solve #39 