### PR TITLE
add missing tests for Operand::required() and Operand::multiple()

### DIFF
--- a/src/Operand.php
+++ b/src/Operand.php
@@ -54,6 +54,9 @@ class Operand extends Argument
         return (bool)($this->mode & self::REQUIRED);
     }
 
+    /**
+     * @return bool
+     */
     public function isMultiple()
     {
         return (bool)($this->mode & self::MULTIPLE);
@@ -61,11 +64,21 @@ class Operand extends Argument
 
     /**
      * @param bool $required
-     * @return self
+     * @return $this
      */
     public function required($required = true)
     {
-        $this->mode += $required ? Operand::REQUIRED : Operand::REQUIRED * -1;
+        $required ? $this->mode |= Operand::REQUIRED : $this->mode &= ~Operand::REQUIRED;
+        return $this;
+    }
+
+    /**
+     * @param bool $multiple
+     * @return $this
+     */
+    public function multiple($multiple = true)
+    {
+        $multiple ? $this->mode |= Operand::MULTIPLE : $this->mode &= ~Operand::MULTIPLE;
         return $this;
     }
 

--- a/test/Operands/CommonTest.php
+++ b/test/Operands/CommonTest.php
@@ -143,4 +143,56 @@ class CommonTest extends TestCase
 
         self::assertNull($result);
     }
+
+    /** @test */
+    public function requireMakesRequired()
+    {
+        $operand = new Operand('op1');
+
+        $operand->required();
+
+        self::assertTrue($operand->isRequired());
+    }
+
+    /** @test */
+    public function requireFalse()
+    {
+        $operand = new Operand('op1', Operand::REQUIRED);
+
+        $operand->required(false);
+
+        self::assertFalse($operand->isRequired());
+    }
+
+    /** @test */
+    public function requireDoesNotMakeAnOperandMultiple()
+    {
+        $operand = new Operand('op1');
+
+        $operand->required();
+        $operand->required();
+
+        self::assertTrue($operand->isRequired());
+        self::assertFalse($operand->isMultiple());
+    }
+
+    /** @test */
+    public function multipleMakesMultiple()
+    {
+        $operand = new Operand('op1');
+
+        $operand->multiple();
+
+        self::assertTrue($operand->isMultiple());
+    }
+
+    /** @test */
+    public function multipleFalse()
+    {
+        $operand = new Operand('op1', Operand::MULTIPLE);
+
+        $operand->multiple(false);
+
+        self::assertFalse($operand->isMultiple());
+    }
 }


### PR DESCRIPTION
The method Operand::multiple() was missing at all. Now both methods work as
expected. A second call will not change the flag again.

This will solve #84 