### PR TITLE
Fixed helpTextWithCustomScriptName test failing on Windows

### DIFF
--- a/test/GetoptTest.php
+++ b/test/GetoptTest.php
@@ -171,7 +171,7 @@ class GetoptTest extends TestCase
     {
         $getopt = new GetOpt();
         $getopt->set(GetOpt::SETTING_SCRIPT_NAME, 'test');
-        $expected = "Usage: test [operands]\n";
+        $expected = 'Usage: test [operands]' . PHP_EOL;
         $this->assertSame($expected, $getopt->getHelpText());
     }
 


### PR DESCRIPTION
On Windows the code emitted `CRLF` but the test was expecting only `LF` (`\n`). It seems the code changes the line-ending character depending on the platform. However, I don't know if the error is in the application or the test. Perhaps the test was correct and the application is behaving incorrectly, however, this PR attempts to fix the test.

Since it seems you have no coverage of the Windows platform I cannot prove this PR fixes anything but perhaps you can test it empirically yourself or consider setting up Windows coverage via [AppVeyor](https://www.appveyor.com/).