### PR TITLE
Remove error redirection from tput invocation for Windows

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit 
+<phpunit
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    stopOnFailure="false"
-    syntaxCheck="true"
+    beStrictAboutOutputDuringTests="true"
 >
     <testsuites>
         <testsuite name="basic">
@@ -32,5 +28,4 @@
             highLowerBound="70"
         />
     </logging>
-
 </phpunit>

--- a/resources/commands.php
+++ b/resources/commands.php
@@ -17,7 +17,7 @@ foreach ($commands as $command) {
     ];
 }
 
-$screenWidth = defined('COLUMNS') ? COLUMNS : @getenv('COLUMNS') ?: @exec('tput cols 2>/dev/null') ?: 90;
+$screenWidth = defined('COLUMNS') ? COLUMNS : @getenv('COLUMNS') ?: @exec('tput cols') ?: 90;
 $screenWidth = min([ isset($maxWidth) ? $maxWidth : 120, $screenWidth ]);
 foreach ($data as $dataRow) {
     $row = sprintf('  % -' . $nameWidth . 's  %s', $dataRow[0], $dataRow[1]);

--- a/resources/options.php
+++ b/resources/options.php
@@ -33,7 +33,7 @@ foreach ($options as $option) {
     ];
 }
 
-$screenWidth = defined('COLUMNS') ? COLUMNS : @getenv('COLUMNS') ?: @exec('tput cols 2>/dev/null') ?: 90;
+$screenWidth = defined('COLUMNS') ? COLUMNS : @getenv('COLUMNS') ?: @exec('tput cols') ?: 90;
 $screenWidth = min([ isset($maxWidth) ? $maxWidth : 120, $screenWidth ]);
 foreach ($data as $dataRow) {
     $row = sprintf('  % -' . $definitionWidth . 's  %s', $dataRow[0], $dataRow[1]);


### PR DESCRIPTION
The `2>/dev/null` error redirection causes `getHelpText()` to emit the following error message twice, each time it is called.

>The system cannot find the path specified. 
>The system cannot find the path specified. 

Since I doubt this command actually emits errors on most systems I suppose it is fairly safe to remove the redirection.

This fixes the problem when I run the program under MINGW64 but in standard Windows environments this just changes the error to:
>'tput' is not recognized as an internal or external command, operable program or batch file.

I suppose this is just a quick fix for what should ultimately be a much more robust solution, such as detecting the availability of `tput`.

---
Aside, I find it very strange that this error is generated under MINGW64 because pasting the command (`tput cols 2>/dev/null`) directly into the console works fine, but for whatever reason, running it via PHP's `exec()` causes it to fail. I also tried `shell_exec()` and `system()` just to see if it made any difference, but it does not.