### PR TITLE
Changed Command API to use 'get' verb for accessor methods

### DIFF
--- a/resources/commands.php
+++ b/resources/commands.php
@@ -7,13 +7,13 @@ echo PHP_EOL . 'Commands:' . PHP_EOL;
 $data      = [];
 $nameWidth = 0;
 foreach ($commands as $command) {
-    if (strlen($command->name()) > $nameWidth) {
-        $nameWidth = strlen($command->name());
+    if (strlen($command->getName()) > $nameWidth) {
+        $nameWidth = strlen($command->getName());
     }
 
     $data[] = [
-        $command->name(),
-        $command->description(true)
+        $command->getName(),
+        $command->getDescription(true)
     ];
 }
 

--- a/resources/usage.php
+++ b/resources/usage.php
@@ -9,7 +9,7 @@ use GetOpt\GetOpt;
 echo 'Usage: ' . $getopt->get(GetOpt::SETTING_SCRIPT_NAME) . ' ';
 
 if (isset($command)) {
-    echo $command->name() . ' ';
+    echo $command->getName() . ' ';
 } elseif ($getopt->hasCommands()) {
     echo '<command> ';
 }
@@ -40,5 +40,5 @@ if (!$lastOperandMultiple && !$getopt->get(GetOpt::SETTING_STRICT_OPERANDS)) {
 echo PHP_EOL;
 
 if (isset($command)) {
-    echo PHP_EOL . $command->description() . PHP_EOL . PHP_EOL;
+    echo PHP_EOL . $command->getDescription() . PHP_EOL . PHP_EOL;
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -111,7 +111,7 @@ class Command
     /**
      * @return string
      */
-    public function name()
+    public function getName()
     {
         return $this->name;
     }
@@ -119,7 +119,7 @@ class Command
     /**
      * @return mixed
      */
-    public function handler()
+    public function getHandler()
     {
         return $this->handler;
     }
@@ -129,12 +129,15 @@ class Command
      *
      * @return string
      */
-    public function description()
+    public function getDescription()
     {
         return $this->longDescription;
     }
 
-    public function shortDescription()
+    /**
+     * @return string
+     */
+    public function getShortDescription()
     {
         return $this->shortDescription;
     }

--- a/src/GetOpt.php
+++ b/src/GetOpt.php
@@ -267,7 +267,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
                 throw new \InvalidArgumentException('$command has conflicting options');
             }
         }
-        $this->commands[$command->name()] = $command;
+        $this->commands[$command->getName()] = $command;
         return $this;
     }
 

--- a/test/CommandTest.php
+++ b/test/CommandTest.php
@@ -31,7 +31,7 @@ class CommandTest extends TestCase
     /** @test */
     public function constructorSavesName()
     {
-        self::assertSame('the-name', $this->command->name());
+        self::assertSame('the-name', $this->command->getName());
     }
 
     /** @dataProvider dataNamesNotAllowed
@@ -55,7 +55,7 @@ class CommandTest extends TestCase
     /** @test */
     public function constructorSavesHandler()
     {
-        self::assertSame([ '\PDO', 'getAvailableDrivers' ], $this->command->handler());
+        self::assertSame([ '\PDO', 'getAvailableDrivers' ], $this->command->getHandler());
     }
 
     /** @test */
@@ -80,7 +80,7 @@ class CommandTest extends TestCase
 
         $command->setShortDescription('short description');
 
-        self::assertSame('short description', $command->description());
+        self::assertSame('short description', $command->getDescription());
     }
 
     /** @test */
@@ -90,7 +90,7 @@ class CommandTest extends TestCase
 
         $command->setDescription('long description');
 
-        self::assertSame('long description', $command->shortDescription());
+        self::assertSame('long description', $command->getShortDescription());
     }
 
     /** @test */


### PR DESCRIPTION
For the next major release, because method names should [always start with a verb](http://codelegance.com/semantic-method-naming/). There may be other classes in need of similar refactoring but this seemed like a good place to start.