### PR TITLE
correcting invalid "$getopt" case in examples

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -51,10 +51,10 @@ $getOpt->addCommand(new DeleteCommand());
 // process arguments and catch user errors
 try {
     try {
-        $getopt->process();
+        $getOpt->process();
     } catch (Missing $exception) {
         // catch missing exceptions if help is requested
-        if (!$getopt->getOption('help')) {
+        if (!$getOpt->getOption('help')) {
             throw $exception;
         }
     }


### PR DESCRIPTION
two instances of $getopt should be $getOpt