### PR TITLE
Add custom validation error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.0
+
+Feature:
+* Added validation custom error message
+
 ## 3.0.0 (alpha)
 
 Features:
@@ -109,4 +114,3 @@ Bugfixes:
 
 Bugfixes:
 * Fixed bug where '0' could not be passed as an option value
-

--- a/docs/options.md
+++ b/docs/options.md
@@ -44,20 +44,20 @@ $getopt = new GetOpt();
 $getopt->addOption($optionAlpha)->addOption($optionBeta);
 ```
 
-The setters can be chained and for convenience there is also a public static method create which allows to write the 
+The setters can be chained and for convenience there is also a public static method create which allows to write the
 above command this way:
 
 ```php
 <?php
 $getopt = new \GetOpt\GetOpt([
-    
+
     \GetOpt\Option::create('a', 'alpha', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
         ->setDescription('This is the description for the alpha option')
         ->setArgument(new \GetOpt\Argument(null, 'is_numeric', 'alpha')),
-    
+
     \GetOpt\Option::create('b', 'beta', \GetOpt\GetOpt::NO_ARGUMENT)
         ->setDescription('This is the description for the beta option'),
-        
+
 ]);
 ```
 
@@ -65,7 +65,7 @@ $getopt = new \GetOpt\GetOpt([
 
 ### Options From String (Short Options Only)
 
-Options can be defined by a string with the exact same syntax as 
+Options can be defined by a string with the exact same syntax as
 [PHP's `getopt()` function](http://php.net/manual/en/function.getopt.php) and the original GNU getopt. It is the
 shortest way to set up GetOpt, but it does not support long options or any advanced features:
 
@@ -89,22 +89,22 @@ can look very clean too:
 ```php
 <?php
 $getopt = new \GetOpt\GetOpt([
-   
+
     // creates an option a without a long alias and with the default argument mode
     ['a'],
-    
+
     // creates an option without a short alias and with the default argument mode
     ['beta'],
-    
+
     // you can define the argument mode
     ['c', \GetOpt\GetOpt::REQUIRED_ARGUMENT],
-    
+
     // you can define long, short, argument mode, description and default value
     ['d', 'delta', \GetOpt\GetOpt::MULTIPLE_ARGUMENT, 'Description for delta', 'default value'],
-    
+
     // note that you have to provide null values if you want to add a desciprtion or default value
     ['e', null, \GetOpt\GetOpt::NO_ARGUMENT, 'Enable something'],
-    
+
 ]);
 ```
 
@@ -192,7 +192,7 @@ foreach ($getopt as $key => $value) {
 }
 // a: value of alpha
 // beta: value
-// verbose: 3 
+// verbose: 3
 ```
 
 Even if foreach does not iterate over the key value pair `['b' => 'value']` you can access it directly:
@@ -271,14 +271,14 @@ $getopt = new \GetOpt\GetOpt([
 $getopt->process('-d example.com --domain example.org');
 
 var_dump($getopt->getOption('domain')); // ['example.com', 'example.org']
-``` 
+```
 
 ### Validation
 
 This library does not come with a bunch of validators that you can use and extend. Instead you provide a callable or
 closure that has to return a truthy value if the value is valid (further called the validator).
 
-The validator gets the value as first and only parameter. For a lot of php standard functions this is enough (eg. 
+The validator gets the value as first and only parameter. For a lot of php standard functions this is enough (eg.
 `is_numeric`). The value will always be a string or null. Here comes an example that shows how to check that it has
 a valid json value:
 
@@ -298,6 +298,47 @@ $ php program.php --data []
 $ php program.php --data '{"a":"alpha"}'
 $ php program.php --data invalid
 ```
+
+#### Validation custom error message
+
+As of version 3.2, you can specify a custom message to be displayed when the validation fails:
+
+```php
+<?php
+$getopt = new \GetOpt\GetOpt([
+    \GetOpt\Option::create(null, 'port', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
+        ->setValidation('is_int', 'The port must be an integer')
+]);
+```
+
+You can also set the message from within the validation closure, since the argument validator is always passed as the second argument to the validation closure:
+
+```php
+<?php
+$getopt = new \GetOpt\GetOpt([
+    \GetOpt\Option::create(null, 'destination', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
+        ->setValidation(function ($value, $validator) {
+            if (!is_dir($value)) {
+                $validator->setMessage('%s is not a directory');
+                return false;
+            }
+
+            if (!is_writable($value)) {
+                $validator->setMessage('The directory %s is not writable');
+                return false;
+            }
+
+            if (count(scandir($value)) === 2) {
+                $validator->setMessage('The directory %s is not empty');
+                return false;
+            }
+            return true;
+        })
+]);
+```
+
+The message will always be evaluated with sprintf and the option/operand name will be passed. You may then, like in the
+example above, use `%s` as a placeholder.
 
 #### Advanced Validation
 
@@ -328,7 +369,7 @@ $getopt->addOptions([
 
 By default only options are allowed that are defined before you run `GetOpt::process()`. This we called
 `STRICT_OPTIONS`. For a quick and dirty application you may want to allow everything. When you setup your `GetOpt` with
-`GetOpt::SETTING_STRICT_OPTIONS = false` every option is allowed with an optional argument. 
+`GetOpt::SETTING_STRICT_OPTIONS = false` every option is allowed with an optional argument.
 
 ```php
 <?php

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -10,7 +10,7 @@ namespace GetOpt;
  */
 class Argument
 {
-    use WithMagicGetter;
+    use WithMagicGetter, WithValidator;
 
     const CLASSNAME = __CLASS__;
 
@@ -56,20 +56,6 @@ class Argument
     }
 
     /**
-     * Set a validation function.
-     * The function must take a string and return true if it is valid, false otherwise.
-     *
-     * @param callable $callable
-     * @return $this
-     * @throws \InvalidArgumentException
-     */
-    public function setValidation(callable $callable)
-    {
-        $this->validation = $callable;
-        return $this;
-    }
-
-    /**
      * @param string $name
      * @return $this
      */
@@ -80,24 +66,13 @@ class Argument
     }
 
     /**
-     * Check if an argument validates according to the specification.
-     *
-     * @param string $arg
-     * @return bool
-     */
-    public function validates($arg)
-    {
-        return (bool)call_user_func($this->validation, $arg);
-    }
-
-    /**
      * Check if the argument has a validation function
-     *
+     * @deprecated
      * @return bool
      */
     public function hasValidation()
     {
-        return isset($this->validation);
+        return $this->hasValidator();
     }
 
     /**

--- a/src/Operand.php
+++ b/src/Operand.php
@@ -90,8 +90,8 @@ class Operand extends Argument
      */
     public function setValue($value)
     {
-        if ($this->validation && !$this->validates($value)) {
-            throw new Invalid(sprintf('Operand %s has an invalid value', $this->name));
+        if (!$this->validates($value)) {
+            throw new Invalid($this->getValidationMessage());
         }
 
         if ($this->isMultiple()) {

--- a/src/Option.php
+++ b/src/Option.php
@@ -13,7 +13,7 @@ use GetOpt\ArgumentException\Missing;
  */
 class Option
 {
-    use WithMagicGetter;
+    use WithMagicGetter, WithValidator;
 
     const CLASSNAME = __CLASS__;
 
@@ -265,6 +265,16 @@ class Option
     }
 
     /**
+     * Retrieve the option's long name preferably, short name otherwise
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getLong() ?: $this->getShort();
+    }
+
+    /**
      * Internal method to set the current value
      *
      * @param mixed $value
@@ -275,7 +285,7 @@ class Option
         if ($value === null && in_array($this->mode, [ GetOpt::REQUIRED_ARGUMENT, GetOpt::MULTIPLE_ARGUMENT ])) {
             throw new Missing(sprintf(
                 'Option \'%s\' must have a value',
-                $this->getLong() ?: $this->getShort()
+                $this->getName()
             ));
         }
 
@@ -283,11 +293,8 @@ class Option
             $value = $this->value === null ? 1 : $this->value + 1;
         }
 
-        if ($this->getArgument()->hasValidation() && !$this->getArgument()->validates($value)) {
-            throw new Invalid(sprintf(
-                'Option \'%s\' has an invalid value',
-                $this->getLong() ?: $this->getShort()
-            ));
+        if (!$this->getArgument()->validates($value)) {
+            throw new Invalid($this->getValidationMessage());
         }
 
         if ($this->mode === GetOpt::MULTIPLE_ARGUMENT) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace GetOpt;
+
+/**
+ * Class Validator
+ *
+ * @package GetOpt
+ * @author Olivier Cecillon <arcesilas@neutre.email>
+ */
+class Validator
+{
+    /** @var callable */
+    protected $callable;
+
+    /** @var string */
+    protected $message;
+
+    /** @var bool */
+    protected $isClosure = false;
+
+    /**
+     * Creates a new Validator object
+     *
+     * @param callable $callable
+     * @param string   $message
+     */
+    public function __construct(callable $callable, $message = '')
+    {
+        $this->callable = $callable;
+        $this->message = $message;
+        $this->isClosure = $callable instanceof \Closure;
+    }
+
+    /**
+     * Check whether the value passed in argument satisfies the validation
+     *
+     * @param  mixed $arg
+     * @return bool
+     */
+    public function validates($arg)
+    {
+        $arguments = $this->isClosure ? [$arg, $this] : [$arg];
+
+        return (bool) call_user_func_array($this->callable, $arguments);
+    }
+
+    /**
+     * Defines a custom message to be displayed if validation fails
+     *
+     * @param string $message
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * Get the custom message
+     *
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/src/WithValidator.php
+++ b/src/WithValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace GetOpt;
+
+trait WithValidator
+{
+    /** @var Validator */
+    protected $validator;
+
+    /**
+     * Set a validation function.
+     * The function must take a string or a callable and return true if it is valid, false otherwise.
+     *
+     * @param callable $callable
+     * @param string   $message
+     */
+    public function setValidation(callable $callable, $message = '')
+    {
+        $this->validator = new Validator($callable, $message);
+        return $this;
+    }
+
+    /**
+     * Check whether a validator has been defined
+     *
+     * @return bool
+     */
+    protected function hasValidator()
+    {
+        return null !== $this->validator;
+    }
+
+    /**
+     * Check if an argument validates according to the specification.
+     *
+     * @param  mixed $arg The value has to be a scalar
+     * @return bool
+     */
+    public function validates($arg)
+    {
+        return $this->hasValidator() ? $this->validator->validates($arg) : true;
+    }
+
+    /**
+     * Returns the validation message from the validator or a default one
+     *
+     * @return string
+     */
+    public function getValidationMessage()
+    {
+        if ($this->hasValidator() && $message = $this->validator->getMessage()) {
+            return sprintf($message, $this->getName());
+        }
+
+        $type = ($this instanceof Operand) ? 'Operand' : 'Option';
+
+        return sprintf("%s '%s' has an invalid value", $type, $this->getName());
+    }
+}

--- a/test/ArgumentTest.php
+++ b/test/ArgumentTest.php
@@ -40,6 +40,50 @@ class ArgumentTest extends TestCase
     }
 
     /** @test */
+    public function doesNotValidateWithoutCustomMessage()
+    {
+        $test = $this;
+        $argument = new Argument();
+        $argument->setValidation(
+            function ($arg, $validator) use ($test, $argument) {
+                $test->assertNotEquals('notthis', $arg);
+            }
+        );
+        $this->assertFalse($argument->validates('test'));
+        $this->assertEquals('Option \'arg\' has an invalid value', $argument->getValidationMessage());
+    }
+
+    /** @test */
+    public function doesNotValidateWithCustomMessage()
+    {
+        $test = $this;
+        $argument = new Argument();
+        $argument->setValidation(
+            function ($arg, $validator) use ($test, $argument) {
+                $test->assertNotEquals('notthis', $arg);
+            },
+            'Custom message: %s'
+        );
+        $this->assertFalse($argument->validates('test'));
+        $this->assertEquals('Custom message: arg', $argument->getValidationMessage());
+    }
+
+    /** @test */
+    public function doesNotValidateWithCustomMessageInClosure()
+    {
+        $test = $this;
+        $argument = new Argument();
+        $argument->setValidation(
+            function ($arg, $validator) use ($test, $argument) {
+                $test->assertNotEquals('notthis', $arg);
+                $validator->setMessage('Custom message: %s');
+            }
+        );
+        $this->assertFalse($argument->validates('test'));
+        $this->assertEquals('Custom message: arg', $argument->getValidationMessage());
+    }
+
+    /** @test */
     public function falsyDefaultValue()
     {
         $argument = new Argument('');

--- a/test/Operands/CommonTest.php
+++ b/test/Operands/CommonTest.php
@@ -5,6 +5,7 @@ namespace GetOpt\Test\Operands;
 use GetOpt\Command;
 use GetOpt\GetOpt;
 use GetOpt\Operand;
+use GetOpt\ArgumentException\Invalid;
 use PHPUnit\Framework\TestCase;
 
 class CommonTest extends TestCase
@@ -46,6 +47,52 @@ class CommonTest extends TestCase
         $getopt->addOperand($operand);
 
         $this->setExpectedException('GetOpt\ArgumentException\Invalid');
+        $getopt->process('"any value"');
+    }
+
+    /** @test */
+    public function operandDoesNotValidateWithoutCustomMessage()
+    {
+        $operand = Operand::create('op1')
+            ->setValidation(function ($value) {
+                return false;
+            });
+
+        $getopt = new GetOpt();
+        $getopt->addOperand($operand);
+
+        $this->setExpectedException('GetOpt\ArgumentException\Invalid', "Operand 'op1' has an invalid value");
+        $getopt->process('"any value"');
+    }
+
+    /** @test */
+    public function operandDoesNotValidateWithCustomMessage()
+    {
+        $operand = Operand::create('op1')
+            ->setValidation(function ($value, $validator) {
+                return false;
+            }, 'Custom message: %s');
+
+        $getopt = new GetOpt();
+        $getopt->addOperand($operand);
+
+        $this->setExpectedException('GetOpt\ArgumentException\Invalid', "Custom message: op1");
+        $getopt->process('"any value"');
+    }
+
+    /** @test */
+    public function operandDoesNotValidateWithCustomMessageInClosure()
+    {
+        $operand = Operand::create('op1')
+            ->setValidation(function ($value, $validator) {
+                $validator->setMessage('Custom message: %s');
+                return false;
+            });
+
+        $getopt = new GetOpt();
+        $getopt->addOperand($operand);
+
+        $this->setExpectedException('GetOpt\ArgumentException\Invalid', "Custom message: op1");
         $getopt->process('"any value"');
     }
 


### PR DESCRIPTION
Hi,

As proposed in #112 I've added the ability to specify custom validation error messages.
I've introduced a new `Validator` class, and gathered the validation related features in a new `WithValidator` trait.
Kept `Argument::hasValidation()` for backward compatibility (because it is public...), and marked it as deprecated.
No BC change has been introduced, tests and CS ok.
Updated documentation and Changelog accordingly.

Note: I think the `Invalid` exception should be thrown in the Validation, rather in the `Operand::setValue()` and `Option::setValue()` methods. The custom message could be defined in the validation when sending the exception. Unfortunately it would make backward compatibility harder to maintain (we would have to handle validation which return `false`, which means much code just for that). Maybe in 4.0...