### PR TITLE
 return empty array for multiple operands when no default value is given

### DIFF
--- a/src/GetOpt.php
+++ b/src/GetOpt.php
@@ -189,7 +189,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
         $arguments->process($this, $setOption, $setCommand, $addOperand);
 
         if (($operand = $this->nextOperand()) && $operand->isRequired() &&
-            (!$operand->isMultiple() || count($this->getOperand($operand->getName())) === 0)
+            (!$operand->isMultiple() || count($operand->getValue()) === 0)
         ) {
             throw new Missing(sprintf('Operand %s is required', $operand->getName()));
         }

--- a/src/Operand.php
+++ b/src/Operand.php
@@ -115,7 +115,7 @@ class Operand extends Argument
         }
 
         if ($this->isMultiple()) {
-            return $this->default !== null ? [ $this->default ] : null;
+            return $this->default !== null ? [ $this->default ] : [];
         }
 
         return $this->default;

--- a/test/Operands/CommonTest.php
+++ b/test/Operands/CommonTest.php
@@ -2,6 +2,7 @@
 
 namespace GetOpt\Test\Operands;
 
+use GetOpt\ArgumentException\Missing;
 use GetOpt\Command;
 use GetOpt\GetOpt;
 use GetOpt\Operand;
@@ -194,5 +195,20 @@ class CommonTest extends TestCase
         $operand->multiple(false);
 
         self::assertFalse($operand->isMultiple());
+    }
+
+    /** @test */
+    public function requiredMultipleThrowsMissing()
+    {
+        $operand = new Operand('port');
+        $operand->multiple(true);
+        $operand->required(true);
+
+        $getOpt = new GetOpt();
+        $getOpt->addOperand($operand);
+
+        $this->setExpectedException('GetOpt\ArgumentException\Missing', 'Operand port is required');
+
+        $getOpt->process('');
     }
 }

--- a/test/Operands/CommonTest.php
+++ b/test/Operands/CommonTest.php
@@ -2,7 +2,6 @@
 
 namespace GetOpt\Test\Operands;
 
-use GetOpt\ArgumentException\Missing;
 use GetOpt\Command;
 use GetOpt\GetOpt;
 use GetOpt\Operand;


### PR DESCRIPTION
This is the same result that we get in version 3.2 and solves #124 and #119 