### PR TITLE
accept any value for options with required argument

### DIFF
--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -57,8 +57,8 @@ class Arguments
             }
 
             if ($this->isLongOption($arg)) {
-                $setOption($this->longName($arg), function () use ($arg) {
-                    return $this->value($arg);
+                $setOption($this->longName($arg), function (Option $option = null) use ($arg) {
+                    return $this->value($arg, null, $option);
                 });
                 continue;
             }
@@ -66,9 +66,9 @@ class Arguments
             // the only left is short options
             foreach ($this->shortNames($arg) as $name) {
                 $requestedValue = false;
-                $setOption($name, function () use ($arg, $name, &$requestedValue) {
+                $setOption($name, function (Option $option = null) use ($arg, $name, &$requestedValue) {
                     $requestedValue = true;
-                    return $this->value($arg, $name);
+                    return $this->value($arg, $name, $option);
                 });
 
                 if ($requestedValue) {
@@ -163,16 +163,20 @@ class Arguments
      *
      * @param string $arg
      * @param string $name
+     * @param Option $option
      * @return string
      */
-    protected function value($arg, $name = null)
+    protected function value($arg, $name = null, Option $option = null)
     {
         $p = strpos($arg, $this->isLongOption($arg) ? '=' : $name);
         if ($this->isLongOption($arg) && $p || !$this->isLongOption($arg) && $p < strlen($arg)-1) {
             return substr($arg, $p+1);
         }
 
-        if (!empty($this->arguments) && $this->isValue($this->arguments[0])) {
+        if (!empty($this->arguments) && (
+                $option && in_array($option->getMode(), [GetOpt::REQUIRED_ARGUMENT, GetOpt::MULTIPLE_ARGUMENT]) ||
+                $this->isValue($this->arguments[0])
+            )) {
             return array_shift($this->arguments);
         }
 

--- a/src/GetOpt.php
+++ b/src/GetOpt.php
@@ -162,7 +162,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
                 }
             }
 
-            $option->setValue($option->getMode() !== GetOpt::NO_ARGUMENT ? $getValue() : null);
+            $option->setValue($option->getMode() !== GetOpt::NO_ARGUMENT ? $getValue($option) : null);
         };
 
         $setCommand = function (Command $command) {

--- a/test/ArgumentsTest.php
+++ b/test/ArgumentsTest.php
@@ -290,14 +290,15 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseNoValueStartingWithHyphenRequired()
+    public function parseValueStartingWithHypenRequired()
     {
-        $this->setExpectedException('GetOpt\ArgumentException\Missing');
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT),
             new Option('b', null)
         ]);
         $this->getopt->process('-a -b');
+
+        self::assertEquals('-b', $this->getopt->getOption('a'));
     }
 
     /** @test */


### PR DESCRIPTION
This resolves #136

Only for options with optional arguments we have to check if the next argument
is an argument or another option. This allows to start arguments with a hyphen
(or dash `-`) like GNUs `getopt`. For optional arguments starting with a hyphen
you still have to provide them within the argument `--foo=-1`.