### PR TITLE
Add CommandInterface

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -8,7 +8,7 @@ namespace GetOpt;
  * @package GetOpt
  * @author  Thomas Flori <thflori@gmail.com>
  */
-class Command
+class Command implements CommandInterface
 {
     use WithOptions, WithOperands, WithMagicGetter;
 

--- a/src/CommandInterface.php
+++ b/src/CommandInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace GetOpt;
+
+/**
+ * Interface CommandInterface
+ *
+ * @package GetOpt
+ * @author Olivier Cecillon <arcesilas@neutre.email>
+ */
+interface CommandInterface
+{
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @return string
+     */
+    public function getDescription();
+
+    /**
+     * @return string
+     */
+    public function getShortDescription();
+
+    /**
+     * Returns the list of operands.
+     *
+     * @return Operand[]
+     */
+    public function getOperands();
+
+    /**
+     * Get all options
+     *
+     * @return Option[]
+     */
+    public function getOptions();
+}

--- a/src/GetOpt.php
+++ b/src/GetOpt.php
@@ -47,11 +47,11 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
     /** @var int */
     protected $operandsCount = 0;
 
-    /** @var Command[] */
+    /** @var CommandInterface[] */
     protected $commands = [];
 
     /** The command that is executed determined by process
-     * @var Command */
+     * @var CommandInterdface */
     protected $command;
 
     /** @var string[] */
@@ -165,7 +165,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
             $option->setValue($option->getMode() !== GetOpt::NO_ARGUMENT ? $getValue($option) : null);
         };
 
-        $setCommand = function (Command $command) {
+        $setCommand = function (CommandInterface $command) {
             $this->addOptions($command->getOptions());
             $this->addOperands($command->getOperands());
             $this->command = $command;
@@ -262,10 +262,10 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
     /**
      * Add a $command
      *
-     * @param Command $command
+     * @param CommandInterface $command
      * @return self
      */
-    public function addCommand(Command $command)
+    public function addCommand(CommandInterface $command)
     {
         foreach ($command->getOptions() as $option) {
             if ($this->conflicts($option)) {


### PR DESCRIPTION
This PR adds `CommandInterface`, implemented by the default `Command` class.

This allows users to define their own commands, with their own creation process and handler implementation.
It does not introduce any BC break.
The methods of the interface are the ones used in the package code. `__construct` and `create` have been deliberately omitted, since they depend on the implementation, just like setters.