### PR TITLE
Fix warning on PHP 7.4

### DIFF
--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -99,7 +99,7 @@ class Arguments
      */
     protected function isValue($arg)
     {
-        return (empty($arg) || $arg === '-' || $arg[0] !== '-');
+        return (empty($arg) || $arg === '-' || 0 !== strpos($arg, '-'));
     }
 
     /**


### PR DESCRIPTION
7.4 comes with a [warning](https://www.php.net/manual/de/migration74.incompatible.php#migration74.incompatible.core.non-array-access) when trying to access array offset on value of type int.

This is to fix one condition that generates some of these warnings.