### PR TITLE
Improve stuffs about assertion call and assertions

### DIFF
--- a/test/Argument/ValidationTest.php
+++ b/test/Argument/ValidationTest.php
@@ -123,8 +123,8 @@ class ValidationTest extends TestCase
         $option = Option::create('a', 'alpha', GetOpt::REQUIRED_ARGUMENT);
         $option->setValidation('is_numeric', function (Describable $object, $value) use ($option) {
 
-            $this->assertSame('foo', $value);
-            $this->assertSame($option, $object);
+            self::assertSame('foo', $value);
+            self::assertSame($option, $object);
 
             return 'anything';
         });
@@ -139,8 +139,8 @@ class ValidationTest extends TestCase
         $operand = Operand::create('alpha');
         $operand->setValidation('is_numeric', function (Describable $object, $value) use ($operand) {
 
-            $this->assertSame('foo', $value);
-            $this->assertSame($operand, $object);
+            self::assertSame('foo', $value);
+            self::assertSame($operand, $object);
 
             return 'anything';
         });

--- a/test/ArgumentTest.php
+++ b/test/ArgumentTest.php
@@ -12,8 +12,8 @@ class ArgumentTest extends TestCase
     {
         $argument1 = new Argument();
         $argument2 = new Argument(10);
-        $this->assertFalse($argument1->hasDefaultValue());
-        $this->assertEquals(10, $argument2->getDefaultValue());
+        self::assertFalse($argument1->hasDefaultValue());
+        self::assertSame(10, $argument2->getDefaultValue());
     }
 
     /** @test */
@@ -31,12 +31,12 @@ class ArgumentTest extends TestCase
         $argument = new Argument();
         $argument->setValidation(
             function ($arg) use ($test, $argument) {
-                $test->assertEquals('test', $arg);
+                $test->assertSame('test', $arg);
                 return true;
             }
         );
-        $this->assertTrue($argument->hasValidation());
-        $this->assertTrue($argument->validates('test'));
+        self::assertTrue($argument->hasValidation());
+        self::assertTrue($argument->validates('test'));
     }
 
     /** @test */

--- a/test/ArgumentsTest.php
+++ b/test/ArgumentsTest.php
@@ -27,7 +27,7 @@ class ArgumentsTest extends TestCase
         self::assertCount(0, $this->getopt->getOptions());
         $operands = $this->getopt->getOperands();
         self::assertCount(1, $operands);
-        self::assertEquals('something', $operands[0]);
+        self::assertSame('something', $operands[0]);
     }
 
     /** @test */
@@ -68,8 +68,8 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-ab');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(1, $options['a']);
-        self::assertEquals(1, $options['b']);
+        self::assertSame(1, $options['a']);
+        self::assertSame(1, $options['b']);
     }
 
     /** @test */
@@ -83,8 +83,8 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a -b -a -a');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(3, $options['a']);
-        self::assertEquals(1, $options['b']);
+        self::assertSame(3, $options['a']);
+        self::assertSame(1, $options['b']);
     }
 
     /** @test */
@@ -98,8 +98,8 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-abaa');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(3, $options['a']);
-        self::assertEquals(1, $options['b']);
+        self::assertSame(3, $options['a']);
+        self::assertSame(1, $options['b']);
     }
 
     /** @test */
@@ -112,7 +112,7 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a value');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('value', $options['a']);
+        self::assertSame('value', $options['a']);
     }
 
     /** @test */
@@ -125,7 +125,7 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a 0');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('0', $options['a']);
+        self::assertSame('0', $options['a']);
     }
 
     /** @test */
@@ -139,8 +139,8 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a 2 -2');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('2', $options['a']);
-        self::assertEquals(1, $options['2']);
+        self::assertSame('2', $options['a']);
+        self::assertSame(1, $options['2']);
     }
 
     /** @test */
@@ -164,8 +164,8 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-ab value');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(1, $options['a']);
-        self::assertEquals('value', $options['b']);
+        self::assertSame(1, $options['a']);
+        self::assertSame('value', $options['b']);
     }
 
     /** @test */
@@ -177,10 +177,10 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a b');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(1, $options['a']);
+        self::assertSame(1, $options['a']);
         $operands = $this->getopt->getOperands();
         self::assertCount(1, $operands);
-        self::assertEquals('b', $operands[0]);
+        self::assertSame('b', $operands[0]);
     }
 
     /** @test */
@@ -191,7 +191,7 @@ class ArgumentsTest extends TestCase
         ]);
         $this->getopt->process('-ppassword');
         $options = $this->getopt->getOptions();
-        self::assertEquals('password', $options['p']);
+        self::assertSame('password', $options['p']);
     }
     /** @test */
     public function parseCollapsedRequiredArgumentWithNoSpace()
@@ -202,8 +202,8 @@ class ArgumentsTest extends TestCase
         ]);
         $this->getopt->process('-vvvppassword');
         $options = $this->getopt->getOptions();
-        self::assertEquals('password', $options['p']);
-        self::assertEquals(3, $options['v']);
+        self::assertSame('password', $options['p']);
+        self::assertSame(3, $options['v']);
     }
 
     /** @test */
@@ -218,8 +218,8 @@ class ArgumentsTest extends TestCase
         self::assertCount(0, $this->getopt->getOptions());
         $operands = $this->getopt->getOperands();
         self::assertCount(2, $operands);
-        self::assertEquals('-a', $operands[0]);
-        self::assertEquals('-b', $operands[1]);
+        self::assertSame('-a', $operands[0]);
+        self::assertSame('-b', $operands[1]);
     }
 
     /** @test */
@@ -231,7 +231,7 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('--option');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(1, $options['option']);
+        self::assertSame(1, $options['option']);
     }
 
     /** @test */
@@ -243,10 +243,10 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('--option something');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(1, $options['option']);
+        self::assertSame(1, $options['option']);
         $operands = $this->getopt->getOperands();
         self::assertCount(1, $operands);
-        self::assertEquals('something', $operands[0]);
+        self::assertSame('something', $operands[0]);
     }
 
     /** @test */
@@ -258,8 +258,8 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('--option value');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('value', $options['option']);
-        self::assertEquals('value', $options['o']);
+        self::assertSame('value', $options['option']);
+        self::assertSame('value', $options['o']);
     }
 
     /** @test */
@@ -271,10 +271,10 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('--option=value something');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('value', $options['option']);
+        self::assertSame('value', $options['option']);
         $operands = $this->getopt->getOperands();
         self::assertCount(1, $operands);
-        self::assertEquals('something', $operands[0]);
+        self::assertSame('something', $operands[0]);
     }
 
     /** @test */
@@ -286,7 +286,7 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('--option=-value');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('-value', $options['option']);
+        self::assertSame('-value', $options['option']);
     }
 
     /** @test */
@@ -298,7 +298,7 @@ class ArgumentsTest extends TestCase
         ]);
         $this->getopt->process('-a -b');
 
-        self::assertEquals('-b', $this->getopt->getOption('a'));
+        self::assertSame('-b', $this->getopt->getOption('a'));
     }
 
     /** @test */
@@ -311,8 +311,8 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a -b');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(1, $options['a']);
-        self::assertEquals(1, $options['b']);
+        self::assertSame(1, $options['a']);
+        self::assertSame(1, $options['b']);
     }
 
     /** @test */
@@ -326,9 +326,9 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a 12');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals(12, $options['a']);
-        self::assertEquals(20, $options['b']);
-        self::assertEquals(20, $options['beta']);
+        self::assertSame('12', $options['a']);
+        self::assertSame(20, $options['b']);
+        self::assertSame(20, $options['beta']);
     }
 
     /** @test */
@@ -338,7 +338,7 @@ class ArgumentsTest extends TestCase
 
         $this->getopt->process('-a value1 -a value2');
 
-        self::assertEquals(['value1', 'value2'], $this->getopt->getOption('a'));
+        self::assertSame(['value1', 'value2'], $this->getopt->getOption('a'));
     }
 
     /** @test */
@@ -350,12 +350,12 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a 0 foo -- bar baz');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('0', $options['a']);
+        self::assertSame('0', $options['a']);
         $operands = $this->getopt->getOperands();
         self::assertCount(3, $operands);
-        self::assertEquals('foo', $operands[0]);
-        self::assertEquals('bar', $operands[1]);
-        self::assertEquals('baz', $operands[2]);
+        self::assertSame('foo', $operands[0]);
+        self::assertSame('bar', $operands[1]);
+        self::assertSame('baz', $operands[2]);
     }
 
     /** @test */
@@ -368,14 +368,14 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a -');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('-', $options['a']);
+        self::assertSame('-', $options['a']);
         $operands = $this->getopt->getOperands();
         self::assertCount(0, $operands);
 
         $this->getopt->process('--alpha -');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('-', $options['a']);
+        self::assertSame('-', $options['a']);
         $operands = $this->getopt->getOperands();
         self::assertCount(0, $operands);
     }
@@ -389,10 +389,10 @@ class ArgumentsTest extends TestCase
         $this->getopt->process('-a 0 -');
 
         $options = $this->getopt->getOptions();
-        self::assertEquals('0', $options['a']);
+        self::assertSame('0', $options['a']);
         $operands = $this->getopt->getOperands();
         self::assertCount(1, $operands);
-        self::assertEquals('-', $operands[0]);
+        self::assertSame('-', $operands[0]);
     }
 
     /** @test */
@@ -405,11 +405,11 @@ class ArgumentsTest extends TestCase
 
         $this->getopt->process('-a 42 operand -b "don\'t panic"');
 
-        self::assertEquals([
-            'a' => 42,
+        self::assertSame([
+            'a' => '42',
             'b' => 'don\'t panic'
         ], $this->getopt->getOptions());
-        self::assertEquals(['operand'], $this->getopt->getOperands());
+        self::assertSame(['operand'], $this->getopt->getOperands());
     }
 
     /** @test */

--- a/test/CommandTest.php
+++ b/test/CommandTest.php
@@ -232,7 +232,7 @@ class CommandTest extends TestCase
 
         $getOpt->parse('import --version reviews');
 
-        self::assertSame(null, $getOpt->getCommand());
+        self::assertNull($getOpt->getCommand());
         self::assertSame(['import', 'reviews'], $getOpt->getOperands());
     }
 }

--- a/test/GetoptTest.php
+++ b/test/GetoptTest.php
@@ -29,9 +29,9 @@ class GetoptTest extends TestCase
 
         $getopt->process('-a aparam -s sparam --long longparam');
 
-        $this->assertEquals('aparam', $getopt->getOption('a'));
-        $this->assertEquals('longparam', $getopt->getOption('long'));
-        $this->assertEquals('sparam', $getopt->getOption('s'));
+        self::assertSame('aparam', $getopt->getOption('a'));
+        self::assertSame('longparam', $getopt->getOption('long'));
+        self::assertSame('sparam', $getopt->getOption('s'));
     }
 
     /** @test */
@@ -44,8 +44,8 @@ class GetoptTest extends TestCase
         ]);
 
         $getopt->process('-s --long longparam');
-        $this->assertEquals('longparam', $getopt->getOption('long'));
-        $this->assertEquals('1', $getopt->getOption('s'));
+        self::assertSame('longparam', $getopt->getOption('long'));
+        self::assertSame(1, $getopt->getOption('s'));
     }
 
     /** @test */
@@ -81,8 +81,8 @@ class GetoptTest extends TestCase
         $getopt->getOption('a', true)->setMode(GetOpt::NO_ARGUMENT);
         $getopt->process('-a foo');
 
-        $this->assertEquals(1, $getopt->getOption('a'));
-        $this->assertEquals('foo', $getopt->getOperand(0));
+        self::assertSame(1, $getopt->getOption('a'));
+        self::assertSame('foo', $getopt->getOperand(0));
     }
 
 
@@ -120,7 +120,7 @@ class GetoptTest extends TestCase
 
         $getopt = new GetOpt('a');
         $getopt->process();
-        $this->assertEquals(1, $getopt->getOption('a'));
+        self::assertSame(1, $getopt->getOption('a'));
     }
 
     /** @test */
@@ -130,14 +130,14 @@ class GetoptTest extends TestCase
         $getopt->process('-a foo');
 
         $options = $getopt->getOptions();
-        $this->assertCount(1, $options);
-        $this->assertEquals(1, $options['a']);
-        $this->assertEquals(1, $getopt->getOption('a'));
+        self::assertCount(1, $options);
+        self::assertSame(1, $options['a']);
+        self::assertSame(1, $getopt->getOption('a'));
 
         $operands = $getopt->getOperands();
-        $this->assertCount(1, $operands);
-        $this->assertEquals('foo', $operands[0]);
-        $this->assertEquals('foo', $getopt->getOperand(0));
+        self::assertCount(1, $operands);
+        self::assertSame('foo', $operands[0]);
+        self::assertSame('foo', $getopt->getOperand(0));
     }
 
     /** @test */
@@ -149,7 +149,7 @@ class GetoptTest extends TestCase
             new Option('c', 'gamma'),
         ]);
         $getopt->process('-abc');
-        $this->assertEquals(3, count($getopt));
+        self::assertSame(3, count($getopt));
     }
 
     /** @test */
@@ -157,7 +157,7 @@ class GetoptTest extends TestCase
     {
         $getopt = new GetOpt('q');
         $getopt->process('-q');
-        $this->assertEquals(1, $getopt['q']);
+        self::assertSame(1, $getopt['q']);
     }
 
     /** @test */
@@ -169,9 +169,10 @@ class GetoptTest extends TestCase
         ]);
         $getopt->process('--alpha -b foo');
 
-        $result = $getopt->getIterator();
+        $result = iterator_to_array($getopt->getIterator());
+        $expected = iterator_to_array(new \ArrayIterator([ 'alpha' => 1, 'beta' => 'foo' ]));
 
-        self::assertEquals(new \ArrayIterator([ 'alpha' => 1, 'beta' => 'foo' ]), $result);
+        self::assertSame($expected, $result);
     }
 
     /** @test */
@@ -182,9 +183,10 @@ class GetoptTest extends TestCase
         ]);
         $getopt->process('--alpha ""');
 
-        $result = $getopt->getIterator();
+        $result = iterator_to_array($getopt->getIterator());
+        $expected = iterator_to_array(new \ArrayIterator([ 'alpha' => '']));
 
-        self::assertEquals(new \ArrayIterator([ 'alpha' => '']), $result);
+        self::assertSame($expected, $result);
     }
 
     /** @test */
@@ -195,7 +197,7 @@ class GetoptTest extends TestCase
 
         $helpText = $getopt->getHelpText();
 
-        $this->assertSame('Usage: test [operands]' . PHP_EOL . PHP_EOL, $helpText);
+        self::assertSame('Usage: test [operands]' . PHP_EOL . PHP_EOL, $helpText);
     }
 
     /** @test */
@@ -208,7 +210,7 @@ class GetoptTest extends TestCase
             Help::DESCRIPTION => 'Running the tests',
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             'Usage: test [operands]' . PHP_EOL . PHP_EOL .
             'Running the tests' . PHP_EOL . PHP_EOL,
             $helpText
@@ -230,7 +232,7 @@ class GetoptTest extends TestCase
         $getopt = new GetOpt();
         $getopt->addOption('c');
 
-        $this->assertEquals(new Option('c', null), $getopt->getOption('c', true));
+        self::assertSame((string)new Option('c', null), (string)$getopt->getOption('c', true));
     }
 
     /** @test */

--- a/test/OptionParserTest.php
+++ b/test/OptionParserTest.php
@@ -21,21 +21,21 @@ class OptionParserTest extends TestCase
     public function parseString()
     {
         $options = $this->parser->parseString('ab:c::3');
-        $this->assertInternalType('array', $options);
-        $this->assertCount(4, $options);
+        self::assertInternalType('array', $options);
+        self::assertCount(4, $options);
         foreach ($options as $option) {
-            $this->assertInstanceOf(Option::CLASSNAME, $option);
-            $this->assertNull($option->getLong());
+            self::assertInstanceOf(Option::CLASSNAME, $option);
+            self::assertNull($option->getLong());
             switch ($option->getShort()) {
                 case 'a':
                 case '3':
-                    $this->assertEquals(GetOpt::NO_ARGUMENT, $option->getMode());
+                    self::assertSame(GetOpt::NO_ARGUMENT, $option->getMode());
                     break;
                 case 'b':
-                    $this->assertEquals(GetOpt::REQUIRED_ARGUMENT, $option->getMode());
+                    self::assertSame(GetOpt::REQUIRED_ARGUMENT, $option->getMode());
                     break;
                 case 'c':
-                    $this->assertEquals(GetOpt::OPTIONAL_ARGUMENT, $option->getMode());
+                    self::assertSame(GetOpt::OPTIONAL_ARGUMENT, $option->getMode());
                     break;
                 default:
                     $this->fail('Unexpected option: '.$option->getShort());
@@ -87,24 +87,24 @@ class OptionParserTest extends TestCase
     {
         $option = $this->parser->parseArray($array);
 
-        $this->assertInstanceOf(Option::CLASSNAME, $option);
+        self::assertInstanceOf(Option::CLASSNAME, $option);
         switch ($option->getShort()) {
             case 'a':
-                $this->assertEquals('alpha', $option->getLong());
-                $this->assertEquals(GetOpt::OPTIONAL_ARGUMENT, $option->getMode());
-                $this->assertEquals('Description', $option->getDescription());
-                $this->assertEquals(42, $option->getArgument()->getDefaultValue());
+                self::assertSame('alpha', $option->getLong());
+                self::assertSame(GetOpt::OPTIONAL_ARGUMENT, $option->getMode());
+                self::assertSame('Description', $option->getDescription());
+                self::assertSame(42, $option->getArgument()->getDefaultValue());
                 break;
             case 'b':
-                $this->assertEquals('beta', $option->getLong());
-                $this->assertEquals(GetOpt::REQUIRED_ARGUMENT, $option->getMode());
-                $this->assertEquals('', $option->getDescription());
+                self::assertSame('beta', $option->getLong());
+                self::assertSame(GetOpt::REQUIRED_ARGUMENT, $option->getMode());
+                self::assertSame('', $option->getDescription());
                 break;
             case 'c':
-                $this->assertNull($option->getLong());
-                $this->assertEquals(GetOpt::REQUIRED_ARGUMENT, $option->getMode());
-                $this->assertEquals('', $option->getDescription());
-                $this->assertFalse($option->getArgument()->hasDefaultValue());
+                self::assertNull($option->getLong());
+                self::assertSame(GetOpt::REQUIRED_ARGUMENT, $option->getMode());
+                self::assertSame('', $option->getDescription());
+                self::assertFalse($option->getArgument()->hasDefaultValue());
                 break;
             default:
                 $this->fail('Unexpected option: '.$option->getShort());

--- a/test/Options/CommonTest.php
+++ b/test/Options/CommonTest.php
@@ -13,18 +13,18 @@ class CommonTest extends TestCase
     public function construct()
     {
         $option = new Option('a', 'az-AZ09_', GetOpt::OPTIONAL_ARGUMENT);
-        $this->assertEquals('a', $option->getShort());
-        $this->assertEquals('az-AZ09_', $option->getLong());
-        $this->assertEquals(GetOpt::OPTIONAL_ARGUMENT, $option->getMode());
+        self::assertSame('a', $option->getShort());
+        self::assertSame('az-AZ09_', $option->getLong());
+        self::assertSame(GetOpt::OPTIONAL_ARGUMENT, $option->getMode());
     }
 
     /** @test */
     public function create()
     {
         $option = Option::create('a', 'az-AZ09_', GetOpt::OPTIONAL_ARGUMENT);
-        $this->assertEquals('a', $option->getShort());
-        $this->assertEquals('az-AZ09_', $option->getLong());
-        $this->assertEquals(GetOpt::OPTIONAL_ARGUMENT, $option->getMode());
+        self::assertSame('a', $option->getShort());
+        self::assertSame('az-AZ09_', $option->getLong());
+        self::assertSame(GetOpt::OPTIONAL_ARGUMENT, $option->getMode());
     }
 
     /** @dataProvider dataConstructFails
@@ -53,8 +53,8 @@ class CommonTest extends TestCase
     public function setArgument()
     {
         $option = new Option('a', null, GetOpt::OPTIONAL_ARGUMENT);
-        $this->assertEquals($option, $option->setArgument(new Argument()));
-        $this->assertInstanceof(Argument::CLASSNAME, $option->getArgument());
+        self::assertSame($option, $option->setArgument(new Argument()));
+        self::assertInstanceof(Argument::CLASSNAME, $option->getArgument());
     }
 
     /** @test */
@@ -69,15 +69,15 @@ class CommonTest extends TestCase
     public function setDefaultValue()
     {
         $option = new Option('a', null, GetOpt::OPTIONAL_ARGUMENT);
-        $this->assertEquals($option, $option->setDefaultValue(10));
-        $this->assertEquals(10, $option->getArgument()->getDefaultValue());
+        self::assertSame($option, $option->setDefaultValue(10));
+        self::assertSame(10, $option->getArgument()->getDefaultValue());
     }
 
     /** @test */
     public function setValidation()
     {
         $option = new Option('a', null, GetOpt::OPTIONAL_ARGUMENT);
-        $this->assertEquals($option, $option->setValidation('is_numeric'));
-        $this->assertTrue($option->getArgument()->hasValidation());
+        self::assertSame($option, $option->setValidation('is_numeric'));
+        self::assertTrue($option->getArgument()->hasValidation());
     }
 }

--- a/test/Options/ValueTest.php
+++ b/test/Options/ValueTest.php
@@ -52,7 +52,7 @@ class ValueTest extends TestCase
         $option->setValue(null);
         $option->setValue(null);
 
-        $this->assertSame('2', (string)$option);
+        self::assertSame('2', (string)$option);
     }
 
     /** @test */
@@ -61,7 +61,7 @@ class ValueTest extends TestCase
         $option = new Option('a', null, GetOpt::REQUIRED_ARGUMENT);
         $option->setValue('valueA');
 
-        $this->assertSame('valueA', (string)$option);
+        self::assertSame('valueA', (string)$option);
     }
 
     /** @test */
@@ -71,7 +71,7 @@ class ValueTest extends TestCase
         $option->setValue('valueA');
         $option->setValue('valueB');
 
-        $this->assertSame('valueA,valueB', (string)$option);
+        self::assertSame('valueA,valueB', (string)$option);
     }
 
     /** @test */
@@ -82,6 +82,6 @@ class ValueTest extends TestCase
 
         $option->setValue(null);
 
-        $this->assertSame(1, $option->getValue());
+        self::assertSame(1, $option->getValue());
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertNull` to assert expected is `null`.
- PHPUnit has two ways to make assertion call. One is `$this` and another one is `self::`.
It seems that using `self::` times is greater than using `$this`.
To be consistency, using the `self` to make assertion call on this repository.
- Using the `assertSame` to replace `assertEquals` and it can let all assertions make equals checking strictly.