### PR TITLE
Minor return type doc tweaks.

### DIFF
--- a/src/GetOpt.php
+++ b/src/GetOpt.php
@@ -280,7 +280,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
      * Get the current or a named command.
      *
      * @param string $name
-     * @return CommandInterface
+     * @return CommandInterface|null
      */
     public function getCommand($name = null)
     {
@@ -312,7 +312,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
     /**
      * Get the next operand
      *
-     * @return Operand
+     * @return Operand|null
      */
     protected function nextOperand()
     {


### PR DESCRIPTION
The getCommand() and nextOperand() methods are documented to always return an object instance, but can also return null.