### PR TITLE
Update type signatures to avoid warnings in PHP 8.1

### DIFF
--- a/src/GetOpt.php
+++ b/src/GetOpt.php
@@ -502,6 +502,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
      * @param mixed $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $option = $this->getOptionObject($offset);
@@ -518,7 +519,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new \LogicException('Read only array access');
     }
@@ -529,7 +530,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
      * @param mixed $offset
      * @throws \LogicException
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new \LogicException('Read only array access');
     }

--- a/src/Option.php
+++ b/src/Option.php
@@ -32,7 +32,7 @@ class Option implements Describable
      *                        or digit) or null for short-only options
      * @param string   $mode  Whether the option can/must have an argument (optional, defaults to no argument)
      */
-    public function __construct(?string $short, string $long = null, string $mode = GetOpt::NO_ARGUMENT)
+    final public function __construct(?string $short, string $long = null, string $mode = GetOpt::NO_ARGUMENT)
     {
         if (!$short && !$long) {
             throw new \InvalidArgumentException("The short and long name may not both be empty");


### PR DESCRIPTION
Also fixes some errors reported by PHPStan