### PR TITLE
test: update tests and config for PHPUnit 9.5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 nbproject
 _site
 .idea/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.1 || ^8.0",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5.20",
+        "phpunit/phpunit": "^9.5.18",
         "squizlabs/php_codesniffer": "^3.5.8"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         stopOnFailure="false"
-         backupGlobals="true"
-         printerClass="\GetOpt\Test\Printer">
-
-    <testsuites>
-        <testsuite name="basic">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    stopOnFailure="false"
+    backupGlobals="true"
+    printerClass="\GetOpt\Test\Printer"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage pathCoverage="false">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <report>
+        <text outputFile="php://stdout" showUncoveredFiles="true" showOnlySummary="false"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="basic">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/Argument/ValidationTest.php
+++ b/test/Argument/ValidationTest.php
@@ -12,14 +12,14 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         GetOpt::setLang('en'); // reset the language
         parent::tearDown();
     }
 
     /** @test */
-    public function defaultMessageForOption()
+    public function defaultMessageForOption(): void
     {
         $option = Option::create('a', 'alpha', GetOpt::REQUIRED_ARGUMENT)
             ->setValidation('is_numeric');
@@ -31,7 +31,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function defaultMessageForOperand()
+    public function defaultMessageForOperand(): void
     {
         $operand = Operand::create('alpha')
             ->setValidation('is_numeric');
@@ -43,7 +43,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function defaultMessageForArgument()
+    public function defaultMessageForArgument(): void
     {
         $argument = new Argument(null, 'is_numeric', 'alpha');
 
@@ -54,7 +54,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function usesCustomMessage()
+    public function usesCustomMessage(): void
     {
         $option = Option::create('a', 'alpha', GetOpt::REQUIRED_ARGUMENT)
             ->setValidation('is_numeric', 'alpha has to be numeric');
@@ -66,7 +66,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function usesTranslatedDescriptions()
+    public function usesTranslatedDescriptions(): void
     {
         GetOpt::setLang('de');
         $operand = Operand::create('alpha')
@@ -79,7 +79,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function providesValueAsSecondReplacement()
+    public function providesValueAsSecondReplacement(): void
     {
         $option = Option::create('a', 'alpha', GetOpt::REQUIRED_ARGUMENT)
             ->setValidation('is_numeric', '%s %s');
@@ -91,7 +91,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function usesCallbackToGetMessage()
+    public function usesCallbackToGetMessage(): void
     {
         $option = Option::create('a', 'alpha', GetOpt::REQUIRED_ARGUMENT)
             ->setValidation('is_numeric', function () {
@@ -105,7 +105,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function providesOptionAndValue()
+    public function providesOptionAndValue(): void
     {
         $option = Option::create('a', 'alpha', GetOpt::REQUIRED_ARGUMENT);
         $option->setValidation('is_numeric', function (Describable $object, $value) use ($option) {
@@ -121,7 +121,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function providesOperandAndValue()
+    public function providesOperandAndValue(): void
     {
         $operand = Operand::create('alpha');
         $operand->setValidation('is_numeric', function (Describable $object, $value) use ($operand) {

--- a/test/ArgumentTest.php
+++ b/test/ArgumentTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class ArgumentTest extends TestCase
 {
     /** @test */
-    public function constructor()
+    public function constructor(): void
     {
         $argument1 = new Argument();
         $argument2 = new Argument(10);
@@ -17,7 +17,7 @@ class ArgumentTest extends TestCase
     }
 
     /** @test */
-    public function setDefaultValueNotScalar()
+    public function setDefaultValueNotScalar(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $argument = new Argument();
@@ -25,7 +25,7 @@ class ArgumentTest extends TestCase
     }
 
     /** @test */
-    public function validates()
+    public function validates(): void
     {
         $test     = $this;
         $argument = new Argument();
@@ -40,7 +40,7 @@ class ArgumentTest extends TestCase
     }
 
     /** @test */
-    public function falsyDefaultValue()
+    public function falsyDefaultValue(): void
     {
         $argument = new Argument('');
 

--- a/test/ArgumentsTest.php
+++ b/test/ArgumentsTest.php
@@ -17,13 +17,13 @@ class ArgumentsTest extends TestCase
     /** @var GetOpt */
     protected $getopt;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->getopt = new GetOpt();
     }
 
     /** @test */
-    public function parseNoOptions()
+    public function parseNoOptions(): void
     {
         $this->getopt->process(Arguments::fromString('something'));
 
@@ -34,7 +34,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseUnknownOption()
+    public function parseUnknownOption(): void
     {
         self::expectException(Unexpected::class);
         $this->getopt->addOption(new Option('a', null));
@@ -43,7 +43,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function unknownLongOption()
+    public function unknownLongOption(): void
     {
         self::expectException(Unexpected::class);
         $this->getopt->addOption(new Option('a', 'alpha'));
@@ -52,7 +52,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseRequiredArgumentMissing()
+    public function parseRequiredArgumentMissing(): void
     {
         self::expectException(Missing::class);
         $this->getopt->addOption(new Option('a', null, GetOpt::REQUIRED_ARGUMENT));
@@ -61,7 +61,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseMultipleOptionsWithOneHyphen()
+    public function parseMultipleOptionsWithOneHyphen(): void
     {
         $this->getopt->addOptions([
             new Option('a'),
@@ -76,7 +76,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseCumulativeOption()
+    public function parseCumulativeOption(): void
     {
         $this->getopt->addOptions([
             new Option('a'),
@@ -91,7 +91,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseCumulativeOptionShort()
+    public function parseCumulativeOptionShort(): void
     {
         $this->getopt->addOptions([
             new Option('a'),
@@ -106,7 +106,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseShortOptionWithArgument()
+    public function parseShortOptionWithArgument(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT)
@@ -119,7 +119,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseZeroArgument()
+    public function parseZeroArgument(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT)
@@ -132,7 +132,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseNumericOption()
+    public function parseNumericOption(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT),
@@ -147,7 +147,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseCollapsedShortOptionsRequiredArgumentMissing()
+    public function parseCollapsedShortOptionsRequiredArgumentMissing(): void
     {
         self::expectException(Missing::class);
         $this->getopt->addOptions([
@@ -158,7 +158,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseCollapsedShortOptionsWithArgument()
+    public function parseCollapsedShortOptionsWithArgument(): void
     {
         $this->getopt->addOptions([
             new Option('a', null),
@@ -172,7 +172,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseNoArgumentOptionAndOperand()
+    public function parseNoArgumentOptionAndOperand(): void
     {
         $this->getopt->addOptions([
             new Option('a', null),
@@ -187,7 +187,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parsedRequiredArgumentWithNoSpace()
+    public function parsedRequiredArgumentWithNoSpace(): void
     {
         $this->getopt->addOptions([
             new Option('p', null, GetOpt::REQUIRED_ARGUMENT)
@@ -197,7 +197,7 @@ class ArgumentsTest extends TestCase
         self::assertSame('password', $options['p']);
     }
     /** @test */
-    public function parseCollapsedRequiredArgumentWithNoSpace()
+    public function parseCollapsedRequiredArgumentWithNoSpace(): void
     {
         $this->getopt->addOptions([
             new Option('v', null),
@@ -210,7 +210,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseOperandsOnly()
+    public function parseOperandsOnly(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT),
@@ -226,7 +226,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseLongOptionWithoutArgument()
+    public function parseLongOptionWithoutArgument(): void
     {
         $this->getopt->addOptions([
             new Option('o', 'option', GetOpt::OPTIONAL_ARGUMENT)
@@ -238,7 +238,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseLongOptionWithoutArgumentAndOperand()
+    public function parseLongOptionWithoutArgumentAndOperand(): void
     {
         $this->getopt->addOptions([
             new Option('o', 'option', GetOpt::NO_ARGUMENT)
@@ -253,7 +253,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseLongOptionWithArgument()
+    public function parseLongOptionWithArgument(): void
     {
         $this->getopt->addOptions([
             new Option('o', 'option', GetOpt::OPTIONAL_ARGUMENT)
@@ -266,7 +266,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseLongOptionWithEqualsSignAndArgument()
+    public function parseLongOptionWithEqualsSignAndArgument(): void
     {
         $this->getopt->addOptions([
             new Option('o', 'option', GetOpt::OPTIONAL_ARGUMENT)
@@ -281,7 +281,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseLongOptionWithValueStartingWithHyphen()
+    public function parseLongOptionWithValueStartingWithHyphen(): void
     {
         $this->getopt->addOptions([
             new Option('o', 'option', GetOpt::REQUIRED_ARGUMENT)
@@ -293,7 +293,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseValueStartingWithHypenRequired()
+    public function parseValueStartingWithHypenRequired(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT),
@@ -305,7 +305,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseNoValueStartingWithHyphenOptional()
+    public function parseNoValueStartingWithHyphenOptional(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::OPTIONAL_ARGUMENT),
@@ -319,7 +319,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseOptionWithDefaultValue()
+    public function parseOptionWithDefaultValue(): void
     {
         $optionA = new Option('a', null, GetOpt::REQUIRED_ARGUMENT);
         $optionA->setArgument(new Argument(10));
@@ -335,7 +335,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function multipleArgumentOptions()
+    public function multipleArgumentOptions(): void
     {
         $this->getopt->addOption(new Option('a', null, GetOpt::MULTIPLE_ARGUMENT));
 
@@ -345,7 +345,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function doubleHyphenNotInOperands()
+    public function doubleHyphenNotInOperands(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT)
@@ -362,7 +362,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function singleHyphenValue()
+    public function singleHyphenValue(): void
     {
         $this->getopt->addOptions([
             new Option('a', 'alpha', GetOpt::REQUIRED_ARGUMENT)
@@ -384,7 +384,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function singleHyphenOperand()
+    public function singleHyphenOperand(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT)
@@ -399,7 +399,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function optionsAfterOperands()
+    public function optionsAfterOperands(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT),
@@ -416,7 +416,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function emptyOperandsAndOptionsWithString()
+    public function emptyOperandsAndOptionsWithString(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT)
@@ -429,7 +429,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function emptyOperandsAndOptionsWithArray()
+    public function emptyOperandsAndOptionsWithArray(): void
     {
         $this->getopt->addOptions([
             new Option('a', null, GetOpt::REQUIRED_ARGUMENT)
@@ -447,7 +447,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function spaceOperand()
+    public function spaceOperand(): void
     {
         $this->getopt->addOptions([]);
 
@@ -457,7 +457,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseWithArgumentValidation()
+    public function parseWithArgumentValidation(): void
     {
         $validation = 'is_numeric';
         $optionA = new Option('a', null, GetOpt::OPTIONAL_ARGUMENT);
@@ -476,7 +476,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function parseInvalidArgument()
+    public function parseInvalidArgument(): void
     {
         self::expectException(Invalid::class);
         $validation = 'is_numeric';
@@ -487,7 +487,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function stringWithSingleQuotes()
+    public function stringWithSingleQuotes(): void
     {
         $this->getopt->addOptions([
             new Option('a', 'optA', GetOpt::REQUIRED_ARGUMENT),
@@ -500,7 +500,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function stringWithDoubleQuotes()
+    public function stringWithDoubleQuotes(): void
     {
         $this->getopt->addOptions([
             new Option('a', 'optA', GetOpt::REQUIRED_ARGUMENT),
@@ -513,7 +513,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function singleQuotesInString()
+    public function singleQuotesInString(): void
     {
         $this->getopt->addOptions([
             new Option('a', 'optA', GetOpt::REQUIRED_ARGUMENT),
@@ -526,7 +526,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function doubleQuotesInString()
+    public function doubleQuotesInString(): void
     {
         $this->getopt->addOptions([
             new Option('a', 'optA', GetOpt::REQUIRED_ARGUMENT),
@@ -539,7 +539,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function quoteConcatenation()
+    public function quoteConcatenation(): void
     {
         $this->getopt->addOptions([
             new Option('a', 'optA', GetOpt::REQUIRED_ARGUMENT),
@@ -554,7 +554,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function quoteEscapingDoubleQuote()
+    public function quoteEscapingDoubleQuote(): void
     {
         $this->getopt->process('-- "this \\" is a double quote"');
 
@@ -562,7 +562,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function quoteEscapingSingleQuote()
+    public function quoteEscapingSingleQuote(): void
     {
         $this->getopt->process("-- 'this \\' is a single quote'");
 
@@ -570,7 +570,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function linefeedAsSeparator()
+    public function linefeedAsSeparator(): void
     {
         $this->getopt->addOptions([
             new Option('a', 'optA', GetOpt::REQUIRED_ARGUMENT),
@@ -583,7 +583,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function tabAsSeparator()
+    public function tabAsSeparator(): void
     {
         $this->getopt->addOptions([
             new Option('a', 'optA', GetOpt::REQUIRED_ARGUMENT),
@@ -596,7 +596,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function explictArguments()
+    public function explictArguments(): void
     {
         $getopt = $this->getopt;
         $this->getopt->addOptions([
@@ -611,7 +611,7 @@ class ArgumentsTest extends TestCase
     }
 
     /** @test */
-    public function usingCommand()
+    public function usingCommand(): void
     {
         $cmd = new Command('test', 'var_dump', [
             new Option('a', 'alpha')

--- a/test/CommandTest.php
+++ b/test/CommandTest.php
@@ -13,7 +13,7 @@ class CommandTest extends TestCase
     protected $command;
     protected $options = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -29,7 +29,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function constructorSavesName()
+    public function constructorSavesName(): void
     {
         self::assertSame('the-name', $this->command->getName());
     }
@@ -37,7 +37,7 @@ class CommandTest extends TestCase
     /** @dataProvider dataNamesNotAllowed
      * @param string $name
      * @test */
-    public function namesNotAllowed($name)
+    public function namesNotAllowed($name): void
     {
         self::expectException(\InvalidArgumentException::class);
         new Command($name, '', null);
@@ -53,19 +53,19 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function constructorSavesHandler()
+    public function constructorSavesHandler(): void
     {
         self::assertSame([ '\PDO', 'getAvailableDrivers' ], $this->command->getHandler());
     }
 
     /** @test */
-    public function constructorSavesOptions()
+    public function constructorSavesOptions(): void
     {
         self::assertSame($this->options, $this->command->getOptions());
     }
 
     /** @test */
-    public function addOptionsAppendsOptions()
+    public function addOptionsAppendsOptions(): void
     {
         $optionC = new Option('c', 'optc');
         $this->command->addOptions([ $optionC ]);
@@ -74,7 +74,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function commandWithConflictingOptionsFailsToAdd()
+    public function commandWithConflictingOptionsFailsToAdd(): void
     {
         $getOpt = new GetOpt([Option::create('v', 'verbose')]);
         $command = new Command('foo', 'var_dump');
@@ -87,7 +87,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function operandsHaveToFollowCommands()
+    public function operandsHaveToFollowCommands(): void
     {
         $getOpt = new GetOpt([Option::create(null, 'version')]);
         $command = new Command('bar', 'var_dump');
@@ -100,7 +100,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function shortDescriptionUsedForDescription()
+    public function shortDescriptionUsedForDescription(): void
     {
         $command = new Command('test', 'var_dump');
 
@@ -110,7 +110,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function descriptionUsedForShortDescription()
+    public function descriptionUsedForShortDescription(): void
     {
         $command = new Command('test', 'var_dump');
 
@@ -120,7 +120,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function getHelpForExecutedCommand()
+    public function getHelpForExecutedCommand(): void
     {
         $longDescription = 'This is a very long description.' . PHP_EOL . 'It also may have line breaks.';
         $getopt = new GetOpt();
@@ -146,7 +146,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function getHelpForCommands()
+    public function getHelpForCommands(): void
     {
         $cmd1 = Command::create('help', 'var_dump')->setDescription('Shows help for a command');
         $cmd2 = Command::create('run:tests', 'var_dump')->setDescription('Executes the tests');
@@ -170,7 +170,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function tooLongShortDescription()
+    public function tooLongShortDescription(): void
     {
         defined('COLUMNS') || define('COLUMNS', 90);
         $getopt = new GetOpt([
@@ -199,7 +199,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function commandsWithSpaces()
+    public function commandsWithSpaces(): void
     {
         $getOpt = new GetOpt();
         $command = Command::create('import reviews', 'var_dump');
@@ -211,7 +211,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function singleWordCommandHavePrecedence()
+    public function singleWordCommandHavePrecedence(): void
     {
         $getOpt = new GetOpt();
         $import = Command::create('import', 'var_dump');
@@ -225,7 +225,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function commandCannotBeDividedByOptions()
+    public function commandCannotBeDividedByOptions(): void
     {
         $getOpt = new GetOpt([Option::create(null, 'version')]);
         $command = Command::create('import reviews', 'var_dump');

--- a/test/GetoptTest.php
+++ b/test/GetoptTest.php
@@ -11,14 +11,14 @@ use PHPUnit\Framework\TestCase;
 
 class GetoptTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         GetOpt::setLang('en');
         parent::tearDown();
     }
 
     /** @test */
-    public function addOptions()
+    public function addOptions(): void
     {
         $getopt = new GetOpt();
         $getopt->addOptions('a:');
@@ -36,7 +36,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function addOptionsChooseShortOrLongAutomatically()
+    public function addOptionsChooseShortOrLongAutomatically(): void
     {
         $getopt = new GetOpt();
         $getopt->addOptions([
@@ -50,7 +50,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function addOptionsUseDefaultArgumentType()
+    public function addOptionsUseDefaultArgumentType(): void
     {
         $getopt = new GetOpt(null, [
             GetOpt::SETTING_DEFAULT_MODE => GetOpt::REQUIRED_ARGUMENT
@@ -65,7 +65,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function addOptionsFailsOnInvalidArgument()
+    public function addOptionsFailsOnInvalidArgument(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $getopt = new GetOpt(null);
@@ -73,7 +73,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function changeModeAfterwards()
+    public function changeModeAfterwards(): void
     {
         $getopt = new GetOpt([
             [ 'a', null, GetOpt::REQUIRED_ARGUMENT ]
@@ -107,7 +107,7 @@ class GetoptTest extends TestCase
      * @test
      * @param array $options
      */
-    public function addOptionsFailsOnConflict($options)
+    public function addOptionsFailsOnConflict($options): void
     {
         self::expectException(\InvalidArgumentException::class);
         $getopt = new GetOpt();
@@ -115,7 +115,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function parseUsesGlobalArgvWhenNoneGiven()
+    public function parseUsesGlobalArgvWhenNoneGiven(): void
     {
         $_SERVER['argv'] = [ 'foo.php', '-a' ];
 
@@ -125,7 +125,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function accessMethods()
+    public function accessMethods(): void
     {
         $getopt = new GetOpt('a');
         $getopt->process('-a foo');
@@ -142,7 +142,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function countable()
+    public function countable(): void
     {
         $getopt = new GetOpt([
             new Option('a', 'alpha'),
@@ -154,7 +154,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function arrayAccess()
+    public function arrayAccess(): void
     {
         $getopt = new GetOpt('q');
         $getopt->process('-q');
@@ -162,7 +162,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function iterable()
+    public function iterable(): void
     {
         $getopt = new GetOpt([
             [ null, 'alpha', GetOpt::NO_ARGUMENT ],
@@ -177,7 +177,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function iteratesOverEmptyStrings()
+    public function iteratesOverEmptyStrings(): void
     {
         $getopt = new GetOpt([
             [ 'a', 'alpha' , GetOpt::REQUIRED_ARGUMENT ]
@@ -191,7 +191,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function helpTextWithCustomScriptName()
+    public function helpTextWithCustomScriptName(): void
     {
         $getopt = new GetOpt();
         $getopt->set(GetOpt::SETTING_SCRIPT_NAME, 'test');
@@ -202,7 +202,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function helpTextWithDescription()
+    public function helpTextWithDescription(): void
     {
         $getopt = new GetOpt();
         $getopt->set(GetOpt::SETTING_SCRIPT_NAME, 'test');
@@ -219,7 +219,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function throwsWithInvalidParameter()
+    public function throwsWithInvalidParameter(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $getopt = new GetOpt();
@@ -228,7 +228,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function addOptionByString()
+    public function addOptionByString(): void
     {
         $getopt = new GetOpt();
         $getopt->addOption('c');
@@ -237,7 +237,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function throwsForUnparsableString()
+    public function throwsForUnparsableString(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $getopt = new GetOpt();
@@ -246,7 +246,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function throwsForInvalidParameter()
+    public function throwsForInvalidParameter(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $getopt = new GetOpt();
@@ -255,7 +255,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function issetArrayAccess()
+    public function issetArrayAccess(): void
     {
         $getopt = new GetOpt();
         $getopt->addOption('a');
@@ -267,7 +267,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function restirctsArraySet()
+    public function restirctsArraySet(): void
     {
         self::expectException(\LogicException::class);
         $getopt = new GetOpt();
@@ -276,7 +276,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function restrictsArrayUnset()
+    public function restrictsArrayUnset(): void
     {
         self::expectException(\LogicException::class);
         $getopt = new GetOpt();
@@ -287,7 +287,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function addCommandWithConflictingOptions()
+    public function addCommandWithConflictingOptions(): void
     {
         self::expectException(\InvalidArgumentException::class);
 
@@ -301,7 +301,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function getCommandByName()
+    public function getCommandByName(): void
     {
         $cmd1 = new Command('help', 'var_dump');
         $cmd2 = new Command('test', 'var_dump');
@@ -315,7 +315,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function setHelpLangToDe()
+    public function setHelpLangToDe(): void
     {
         $getopt = new GetOpt();
         $getopt->set(GetOpt::SETTING_SCRIPT_NAME, 'test');
@@ -333,7 +333,7 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
-    public function returnsFalseWhenFileDoesNotExist()
+    public function returnsFalseWhenFileDoesNotExist(): void
     {
         $getopt = new GetOpt();
 

--- a/test/Help/TemplateTest.php
+++ b/test/Help/TemplateTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 class TemplateTest extends TestCase
 {
     /** @test */
-    public function rendersUsageTemplate()
+    public function rendersUsageTemplate(): void
     {
         $getOpt = new GetOpt();
         $scriptName = $getOpt->get(GetOpt::SETTING_SCRIPT_NAME);
@@ -25,7 +25,7 @@ class TemplateTest extends TestCase
     }
 
     /** @test */
-    public function rendersOptionsTemplate()
+    public function rendersOptionsTemplate(): void
     {
         $getOpt = new GetOpt([
             Option::create('a', 'alpha', GetOpt::OPTIONAL_ARGUMENT),
@@ -47,7 +47,7 @@ class TemplateTest extends TestCase
     }
 
     /** @test */
-    public function rendersCommandsTemplate()
+    public function rendersCommandsTemplate(): void
     {
         $getOpt = new GetOpt();
         $getOpt->addCommand(Command::create('test', 'var_dump')->setDescription('Run this tests'));

--- a/test/MagicGettersTest.php
+++ b/test/MagicGettersTest.php
@@ -14,7 +14,7 @@ class MagicGettersTest extends TestCase
 {
     /** @dataProvider provideGetOptAttributes
      * @test */
-    public function getOptUsesMagicGetters($getOpt, $attribute, $expected)
+    public function getOptUsesMagicGetters($getOpt, $attribute, $expected): void
     {
         $result = $getOpt->{$attribute};
 
@@ -49,7 +49,7 @@ class MagicGettersTest extends TestCase
 
     /** @dataProvider provideCommandAttributes
      * @test */
-    public function commandUsesMagicGetters($command, $attribute, $expected)
+    public function commandUsesMagicGetters($command, $attribute, $expected): void
     {
         $result = $command->{$attribute};
 
@@ -74,7 +74,7 @@ class MagicGettersTest extends TestCase
 
     /** @dataProvider provideArgumentAttributes
      * @test */
-    public function argumentUsesMagicGetters($argument, $attribute, $expected)
+    public function argumentUsesMagicGetters($argument, $attribute, $expected): void
     {
         $result = $argument->{$attribute};
 
@@ -93,7 +93,7 @@ class MagicGettersTest extends TestCase
 
     /** @dataProvider provideOperandAttributes
      * @test */
-    public function operandUsesMagicGetters($operand, $attribute, $expected)
+    public function operandUsesMagicGetters($operand, $attribute, $expected): void
     {
         $result = $operand->{$attribute};
 
@@ -113,7 +113,7 @@ class MagicGettersTest extends TestCase
 
     /** @dataProvider provideOptionAttributes
      * @test */
-    public function optionUsesMagicGetters($option, $attribute, $expected)
+    public function optionUsesMagicGetters($option, $attribute, $expected): void
     {
         $result = $option->{$attribute};
 

--- a/test/Operands/CommonTest.php
+++ b/test/Operands/CommonTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 class CommonTest extends TestCase
 {
     /** @test */
-    public function operandsAreResetted()
+    public function operandsAreResetted(): void
     {
         $getopt = new GetOpt();
         $getopt->process('"any operand"');
@@ -23,7 +23,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function addOperands()
+    public function addOperands(): void
     {
         $operand1 = new Operand('op1');
         $operand2 = new Operand('op2');
@@ -37,7 +37,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function operandValidation()
+    public function operandValidation(): void
     {
         $operand = Operand::create('op1')
             ->setValidation(function ($value) {
@@ -52,7 +52,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function optionalOperand()
+    public function optionalOperand(): void
     {
         $operand = new Operand('op1', Operand::OPTIONAL); // false is default
 
@@ -64,7 +64,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function requiredOperand()
+    public function requiredOperand(): void
     {
         $operand = new Operand('op1', Operand::REQUIRED);
 
@@ -76,7 +76,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function getOperandByName()
+    public function getOperandByName(): void
     {
         $operand = new Operand('op1');
 
@@ -88,7 +88,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function defaultValue()
+    public function defaultValue(): void
     {
         $operand = Operand::create('op1')
             ->setDefaultValue(42);
@@ -101,7 +101,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function allPreviousOperandsGetRequiredToo()
+    public function allPreviousOperandsGetRequiredToo(): void
     {
         $operand1 = new Operand('op1', Operand::OPTIONAL);
         $operand2 = new Operand('op2', Operand::REQUIRED);
@@ -113,7 +113,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function commandsCanHaveOperands()
+    public function commandsCanHaveOperands(): void
     {
         $operand = new Operand('op1');
         $command = new Command('command1', 'var_dump');
@@ -123,7 +123,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function commandWithOperand()
+    public function commandWithOperand(): void
     {
         $getopt = new GetOpt();
         $command = new Command('command', 'var_dump');
@@ -137,7 +137,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function returnsNullForUnknownOperands()
+    public function returnsNullForUnknownOperands(): void
     {
         $getopt = new GetOpt();
 
@@ -147,7 +147,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function requireMakesRequired()
+    public function requireMakesRequired(): void
     {
         $operand = new Operand('op1');
 
@@ -157,7 +157,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function requireFalse()
+    public function requireFalse(): void
     {
         $operand = new Operand('op1', Operand::REQUIRED);
 
@@ -167,7 +167,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function requireDoesNotMakeAnOperandMultiple()
+    public function requireDoesNotMakeAnOperandMultiple(): void
     {
         $operand = new Operand('op1');
 
@@ -179,7 +179,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function multipleMakesMultiple()
+    public function multipleMakesMultiple(): void
     {
         $operand = new Operand('op1');
 
@@ -189,7 +189,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function multipleFalse()
+    public function multipleFalse(): void
     {
         $operand = new Operand('op1', Operand::MULTIPLE);
 
@@ -199,7 +199,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function requiredMultipleThrowsMissing()
+    public function requiredMultipleThrowsMissing(): void
     {
         $operand = new Operand('port');
         $operand->multiple(true);

--- a/test/Operands/HelpTest.php
+++ b/test/Operands/HelpTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 class HelpTest extends TestCase
 {
     /** @test */
-    public function helpContainsOperandNames()
+    public function helpContainsOperandNames(): void
     {
         $operand1 = new Operand('op1', true);
         $operand2 = new Operand('op2', false);
@@ -28,7 +28,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function helpCommandDefinesOperands()
+    public function helpCommandDefinesOperands(): void
     {
         $operand1 = new Operand('op1', true);
         $operand2 = new Operand('op2', false);
@@ -52,7 +52,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function helpTextForMultiple()
+    public function helpTextForMultiple(): void
     {
         $operand = new Operand('op1', Operand::MULTIPLE);
         $script = $_SERVER['PHP_SELF'];
@@ -67,7 +67,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function helpTextForRequiredMultiple()
+    public function helpTextForRequiredMultiple(): void
     {
         $operand = new Operand('op1', Operand::MULTIPLE + Operand::REQUIRED);
         $script = $_SERVER['PHP_SELF'];
@@ -82,7 +82,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function showsDescriptionsBeforeOptions()
+    public function showsDescriptionsBeforeOptions(): void
     {
         $script = $_SERVER['PHP_SELF'];
         $getOpt = new GetOpt(null, [GetOpt::SETTING_STRICT_OPERANDS => true]);
@@ -105,7 +105,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function hidesDescriptionsIfRequested()
+    public function hidesDescriptionsIfRequested(): void
     {
         $script = $_SERVER['PHP_SELF'];
         $getOpt = new GetOpt(null, [GetOpt::SETTING_STRICT_OPERANDS => true]);

--- a/test/Operands/MultipleTest.php
+++ b/test/Operands/MultipleTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 class MultipleTest extends TestCase
 {
     /** @test */
-    public function valueForMultiple()
+    public function valueForMultiple(): void
     {
         $operand1 = new Operand('op1', Operand::OPTIONAL);
         $operand2 = new Operand('op2', Operand::MULTIPLE);
@@ -26,7 +26,7 @@ class MultipleTest extends TestCase
     }
 
     /** @test */
-    public function defaultValueForMultiple()
+    public function defaultValueForMultiple(): void
     {
         $operand = Operand::create('op1', Operand::MULTIPLE)
             ->setDefaultValue(42);
@@ -39,7 +39,7 @@ class MultipleTest extends TestCase
     }
 
     /** @test */
-    public function requiredMultiple()
+    public function requiredMultiple(): void
     {
         $operand = new Operand('op1', true, null, null, true);
 
@@ -51,7 +51,7 @@ class MultipleTest extends TestCase
     }
 
     /** @test */
-    public function requiredMultipleNotToThrow()
+    public function requiredMultipleNotToThrow(): void
     {
         $operand = new Operand('op1', Operand::REQUIRED + Operand::MULTIPLE);
 
@@ -63,7 +63,7 @@ class MultipleTest extends TestCase
     }
 
     /** @test */
-    public function validationOfMultiple()
+    public function validationOfMultiple(): void
     {
         $operand1 = Operand::create('op1', Operand::MULTIPLE)
             ->setValidation(function ($value) {
@@ -78,7 +78,7 @@ class MultipleTest extends TestCase
     }
 
     /** @test */
-    public function restrictsAddingAfterMultiple()
+    public function restrictsAddingAfterMultiple(): void
     {
         $operand1 = new Operand('op1', Operand::MULTIPLE);
         $operand2 = new Operand('op2', Operand::OPTIONAL);

--- a/test/Operands/StrictTest.php
+++ b/test/Operands/StrictTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class StrictTest extends TestCase
 {
     /** @test */
-    public function noOperandsAllowed()
+    public function noOperandsAllowed(): void
     {
         $getopt = new GetOpt();
         $getopt->set(GetOpt::SETTING_STRICT_OPERANDS, true);
@@ -20,7 +20,7 @@ class StrictTest extends TestCase
     }
 
     /** @test */
-    public function specifiedOperandsAllowed()
+    public function specifiedOperandsAllowed(): void
     {
         $getopt = new GetOpt();
         $getopt->set(GetOpt::SETTING_STRICT_OPERANDS, true);
@@ -32,7 +32,7 @@ class StrictTest extends TestCase
     }
 
     /** @test */
-    public function helpDoesNotShowAdditionalOperands()
+    public function helpDoesNotShowAdditionalOperands(): void
     {
         $getopt = new GetOpt();
         $getopt->set(GetOpt::SETTING_STRICT_OPERANDS, true);

--- a/test/Operands/ValueTest.php
+++ b/test/Operands/ValueTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class ValueTest extends TestCase
 {
     /** @test */
-    public function toStringWithoutValue()
+    public function toStringWithoutValue(): void
     {
         $operand = Operand::create('file');
 
@@ -16,7 +16,7 @@ class ValueTest extends TestCase
     }
 
     /** @test */
-    public function toStringWithDefaultValue()
+    public function toStringWithDefaultValue(): void
     {
         $operand = Operand::create('file')
             ->setDefaultValue('/dev/random');
@@ -25,7 +25,7 @@ class ValueTest extends TestCase
     }
 
     /** @test */
-    public function toStringWithValue()
+    public function toStringWithValue(): void
     {
         $operand = Operand::create('file');
 
@@ -35,7 +35,7 @@ class ValueTest extends TestCase
     }
 
     /** @test */
-    public function toStringWithMultipleValue()
+    public function toStringWithMultipleValue(): void
     {
         $operand = Operand::create('files', Operand::MULTIPLE);
 

--- a/test/OptionParserTest.php
+++ b/test/OptionParserTest.php
@@ -12,16 +12,16 @@ class OptionParserTest extends TestCase
     /** @var OptionParser */
     private $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->parser = new OptionParser(GetOpt::REQUIRED_ARGUMENT);
     }
 
     /** @test */
-    public function parseString()
+    public function parseString(): void
     {
         $options = $this->parser->parseString('ab:c::3');
-        self::assertInternalType('array', $options);
+        self::assertIsArray($options);
         self::assertCount(4, $options);
         foreach ($options as $option) {
             self::assertInstanceOf(Option::CLASSNAME, $option);
@@ -44,28 +44,28 @@ class OptionParserTest extends TestCase
     }
 
     /** @test */
-    public function parseStringEmpty()
+    public function parseStringEmpty(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $this->parser->parseString('');
     }
 
     /** @test */
-    public function parseStringInvalidCharacter()
+    public function parseStringInvalidCharacter(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $this->parser->parseString('ab:c::dä');
     }
 
     /** @test */
-    public function parseStringStartsWithColon()
+    public function parseStringStartsWithColon(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $this->parser->parseString(':ab:c::d');
     }
 
     /** @test */
-    public function parseStringTripleColon()
+    public function parseStringTripleColon(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $this->parser->parseString('ab:c:::d');
@@ -83,7 +83,7 @@ class OptionParserTest extends TestCase
     /** @dataProvider provideOptionArrays
      * @param array $array
      * @test */
-    public function parseArray($array)
+    public function parseArray($array): void
     {
         $option = $this->parser->parseArray($array);
 
@@ -112,14 +112,14 @@ class OptionParserTest extends TestCase
     }
 
     /** @test */
-    public function parseArrayEmpty()
+    public function parseArrayEmpty(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $this->parser->parseArray([]);
     }
 
     /** @test */
-    public function parseArrayInvalid()
+    public function parseArrayInvalid(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $this->parser->parseArray([ 'a', '_' ]);

--- a/test/Options/CommonTest.php
+++ b/test/Options/CommonTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class CommonTest extends TestCase
 {
     /** @test */
-    public function construct()
+    public function construct(): void
     {
         $option = new Option('a', 'az-AZ09_', GetOpt::OPTIONAL_ARGUMENT);
         self::assertSame('a', $option->getShort());
@@ -19,7 +19,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function create()
+    public function create(): void
     {
         $option = Option::create('a', 'az-AZ09_', GetOpt::OPTIONAL_ARGUMENT);
         self::assertSame('a', $option->getShort());
@@ -32,7 +32,7 @@ class CommonTest extends TestCase
      * @param string $long
      * @param int    $mode
      * @test */
-    public function constructFails($short, $long, $mode)
+    public function constructFails($short, $long, $mode): void
     {
         self::expectException(\InvalidArgumentException::class);
         new Option($short, $long, $mode);
@@ -50,7 +50,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function setArgument()
+    public function setArgument(): void
     {
         $option = new Option('a', null, GetOpt::OPTIONAL_ARGUMENT);
         self::assertSame($option, $option->setArgument(new Argument()));
@@ -58,7 +58,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function setArgumentWrongMode()
+    public function setArgumentWrongMode(): void
     {
         self::expectException(\InvalidArgumentException::class);
         $option = new Option('a', null, GetOpt::NO_ARGUMENT);
@@ -66,7 +66,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function setDefaultValue()
+    public function setDefaultValue(): void
     {
         $option = new Option('a', null, GetOpt::OPTIONAL_ARGUMENT);
         self::assertSame($option, $option->setDefaultValue(10));
@@ -74,7 +74,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function setValidation()
+    public function setValidation(): void
     {
         $option = new Option('a', null, GetOpt::OPTIONAL_ARGUMENT);
         self::assertSame($option, $option->setValidation('is_numeric'));

--- a/test/Options/HelpTest.php
+++ b/test/Options/HelpTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class HelpTest extends TestCase
 {
     /** @test */
-    public function helpText()
+    public function helpText(): void
     {
         $getopt = new GetOpt([
             [ 'a', 'alpha', GetOpt::NO_ARGUMENT, 'Short and long options with no argument' ],
@@ -32,7 +32,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function helpTextWithoutDescriptions()
+    public function helpTextWithoutDescriptions(): void
     {
         $getopt = new GetOpt([
             [ 'a', 'alpha', GetOpt::NO_ARGUMENT ],
@@ -53,7 +53,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function helpTextWithLongDescriptions()
+    public function helpTextWithLongDescriptions(): void
     {
         defined('COLUMNS') || define('COLUMNS', 90);
 
@@ -79,7 +79,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function longWordsInDescription()
+    public function longWordsInDescription(): void
     {
         defined('COLUMNS') || define('COLUMNS', 90);
 
@@ -105,7 +105,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function helpTextWithArgumentName()
+    public function helpTextWithArgumentName(): void
     {
         $getopt = new GetOpt([
             Option::create('a', 'alpha', GetOpt::REQUIRED_ARGUMENT)
@@ -122,7 +122,7 @@ class HelpTest extends TestCase
     }
 
     /** @test */
-    public function textsGetUsed()
+    public function textsGetUsed(): void
     {
         $getopt = new GetOpt([Option::create('a', 'alpha')]);
 

--- a/test/Options/NonStrictTest.php
+++ b/test/Options/NonStrictTest.php
@@ -10,7 +10,7 @@ class NonStrictTest extends TestCase
     /** @var GetOpt */
     protected $getopt;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->getopt = new GetOpt(null, [
             GetOpt::SETTING_STRICT_OPTIONS => false,
@@ -18,7 +18,7 @@ class NonStrictTest extends TestCase
     }
 
     /** @test */
-    public function additionalOptionsDoNotThrow()
+    public function additionalOptionsDoNotThrow(): void
     {
         $this->getopt->process('-a --beta');
 
@@ -26,7 +26,7 @@ class NonStrictTest extends TestCase
     }
 
     /** @test */
-    public function storesTheArgument()
+    public function storesTheArgument(): void
     {
         $this->getopt->process('-a aValue --beta betaValue -ccValue');
 
@@ -39,7 +39,7 @@ class NonStrictTest extends TestCase
     }
 
     /** @test */
-    public function additionalOptionsAreResetted()
+    public function additionalOptionsAreResetted(): void
     {
         $this->getopt->process('-a aValue --beta betaValue -ccValue');
 
@@ -49,7 +49,7 @@ class NonStrictTest extends TestCase
     }
 
     /** @test */
-    public function iteratesOverAdditionalOptions()
+    public function iteratesOverAdditionalOptions(): void
     {
         $this->getopt->process('-a aValue --beta betaValue');
 
@@ -60,7 +60,7 @@ class NonStrictTest extends TestCase
     }
 
     /** @test */
-    public function offsetExists()
+    public function offsetExists(): void
     {
         $this->getopt->process('--alpha alphaValue');
 
@@ -68,7 +68,7 @@ class NonStrictTest extends TestCase
     }
 
     /** @test */
-    public function offsetGet()
+    public function offsetGet(): void
     {
         $this->getopt->process('--alpha alphaValue');
 
@@ -76,7 +76,7 @@ class NonStrictTest extends TestCase
     }
 
     /** @test */
-    public function storesTheCountWithoutValue()
+    public function storesTheCountWithoutValue(): void
     {
         $this->getopt->process('-a -a -a');
 
@@ -84,7 +84,7 @@ class NonStrictTest extends TestCase
     }
 
     /** @test */
-    public function showsOptionsInUsage()
+    public function showsOptionsInUsage(): void
     {
         $script = $_SERVER['PHP_SELF'];
 

--- a/test/Options/ValueTest.php
+++ b/test/Options/ValueTest.php
@@ -12,7 +12,7 @@ class ValueTest extends TestCase
      * @param Option $option
      * @param mixed  $expected
      * @test */
-    public function valueWithoutDefault(Option $option, $expected)
+    public function valueWithoutDefault(Option $option, $expected): void
     {
         $result = $option->getValue();
 
@@ -25,7 +25,7 @@ class ValueTest extends TestCase
      * @param mixed  $value
      * @param mixed  $expected
      * @test */
-    public function valueWithoutDefaultButSetValue(Option $option, $dummy, $value, $expected)
+    public function valueWithoutDefaultButSetValue(Option $option, $dummy, $value, $expected): void
     {
         $option->setValue($value);
 
@@ -46,7 +46,7 @@ class ValueTest extends TestCase
     }
 
     /** @test */
-    public function toStringWithoutArgument()
+    public function toStringWithoutArgument(): void
     {
         $option = new Option('a', null);
         $option->setValue(null);
@@ -56,7 +56,7 @@ class ValueTest extends TestCase
     }
 
     /** @test */
-    public function toStringWithArgument()
+    public function toStringWithArgument(): void
     {
         $option = new Option('a', null, GetOpt::REQUIRED_ARGUMENT);
         $option->setValue('valueA');
@@ -65,7 +65,7 @@ class ValueTest extends TestCase
     }
 
     /** @test */
-    public function toStringWithMultipleArguments()
+    public function toStringWithMultipleArguments(): void
     {
         $option = new Option('a', null, GetOpt::MULTIPLE_ARGUMENT);
         $option->setValue('valueA');
@@ -75,7 +75,7 @@ class ValueTest extends TestCase
     }
 
     /** @test */
-    public function defaultValueNotUsedForCounting()
+    public function defaultValueNotUsedForCounting(): void
     {
         $option = new Option('a', null, GetOpt::OPTIONAL_ARGUMENT);
         $option->setDefaultValue(42);

--- a/test/Printer.php
+++ b/test/Printer.php
@@ -5,9 +5,9 @@ namespace GetOpt\Test;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\Warning;
-use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\TextUI\DefaultResultPrinter;
 
-class Printer extends ResultPrinter
+class Printer extends DefaultResultPrinter
 {
     /**
      * Replacement symbols for test statuses.
@@ -119,17 +119,17 @@ class Printer extends ResultPrinter
      * @param $time
      * @param $color
      */
-    protected function buildTestRow($className, $methodName, $time, $color = 'fg-white')
+    protected function buildTestRow($className, $methodName, $time, $color = 'fg-white'): void
     {
         if ($className != $this->previousClassName) {
-            $this->write(PHP_EOL . $this->formatWithColor('fg-magenta', $className) . PHP_EOL);
+            $this->write(PHP_EOL . $this->colorizeTextBox('fg-magenta', $className) . PHP_EOL);
             $this->previousClassName = $className;
         }
 
         $this->testRow = sprintf(
             "(%s) %s",
             $this->formatTestDuration($time),
-            $this->formatWithColor($color, "{$this->formatMethodName($methodName)}")
+            $this->colorizeTextBox($color, "{$this->formatMethodName($methodName)}")
         );
     }
     /**
@@ -176,7 +176,7 @@ class Printer extends ResultPrinter
     {
         $testDurationInMs = round($time * 1000);
         $duration = $testDurationInMs > 500
-            ? $this->formatWithColor('fg-yellow', $testDurationInMs)
+            ? $this->colorizeTextBox('fg-yellow', $testDurationInMs)
             : $testDurationInMs;
         return sprintf('%s ms', $duration);
     }

--- a/test/Translator/CommonTest.php
+++ b/test/Translator/CommonTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class CommonTest extends TestCase
 {
     /** @test */
-    public function throwsWhenLanguageNotAvailable()
+    public function throwsWhenLanguageNotAvailable(): void
     {
         self::expectException(\InvalidArgumentException::class);
 
@@ -16,7 +16,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function usesTranslationFile()
+    public function usesTranslationFile(): void
     {
         $translator = new Translator(__DIR__ . '/incomplete-translation.php');
 
@@ -26,7 +26,7 @@ class CommonTest extends TestCase
     }
 
     /** @test */
-    public function usesFallBackTranslation()
+    public function usesFallBackTranslation(): void
     {
         $translator = new Translator(__DIR__ . '/incomplete-translation.php');
 


### PR DESCRIPTION
All tests run now with PHPUnit 9.5.18 + text report of code coverage (tested with ext-pcov).