### PR TITLE
Fix php8.4 deprecated errors

### DIFF
--- a/src/Argument.php
+++ b/src/Argument.php
@@ -77,10 +77,10 @@ class Argument implements Describable
      * The function must take a string and return true if it is valid, false otherwise.
      *
      * @param callable        $callable
-     * @param string|callable|null $message
+     * @param string|callable|null $message (not typed for compatibility)
      * @return $this
      */
-    public function setValidation(callable $callable, string|callable|null $message = null): Argument
+    public function setValidation(callable $callable, $message = null): Argument
     {
         $this->validation        = $callable;
         $this->validationMessage = $message;

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -45,7 +45,7 @@ class Argument implements Describable
      * @param ?callable $validation A validation function
      * @param string    $name       A name for the argument
      */
-    public function __construct($default = null, callable $validation = null, $name = "arg")
+    public function __construct($default = null, ?callable $validation = null, $name = "arg")
     {
         if (!is_null($default)) {
             $this->setDefaultValue($default);
@@ -77,10 +77,10 @@ class Argument implements Describable
      * The function must take a string and return true if it is valid, false otherwise.
      *
      * @param callable        $callable
-     * @param string|callable $message
+     * @param string|callable|null $message
      * @return $this
      */
-    public function setValidation(callable $callable, $message = null): Argument
+    public function setValidation(callable $callable, string|callable|null $message = null): Argument
     {
         $this->validation        = $callable;
         $this->validationMessage = $message;

--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -58,7 +58,7 @@ class Arguments
             }
 
             if ($this->isLongOption($arg)) {
-                $setOption($this->longName($arg), function (Option $option = null) use ($arg) {
+                $setOption($this->longName($arg), function (?Option $option = null) use ($arg) {
                     return $this->value($arg, null, $option);
                 });
                 continue;
@@ -67,7 +67,7 @@ class Arguments
             // the only left is short options
             foreach ($this->shortNames($arg) as $name) {
                 $requestedValue = false;
-                $setOption($name, function (Option $option = null) use ($arg, $name, &$requestedValue) {
+                $setOption($name, function (?Option $option = null) use ($arg, $name, &$requestedValue) {
                     $requestedValue = true;
                     return $this->value($arg, $name, $option);
                 });
@@ -181,11 +181,11 @@ class Arguments
      * Returns the value inside $arg or the next argument when it is a value.
      *
      * @param string $arg
-     * @param string $name
+     * @param ?string $name
      * @param ?Option $option
      * @return ?string
      */
-    protected function value(string $arg, $name = null, Option $option = null): ?string
+    protected function value(string $arg, ?string $name = null, ?Option $option = null): ?string
     {
         $p = strpos($arg, $this->isLongOption($arg) ? '=' : $name);
         if ($this->isLongOption($arg) && $p || !$this->isLongOption($arg) && $p < strlen($arg)-1) {

--- a/src/Option.php
+++ b/src/Option.php
@@ -98,10 +98,10 @@ class Option implements Describable
      * Defines a validation function for the option.
      *
      * @param callable        $function
-     * @param string|callable|null $message
+     * @param string|callable|null $message (not typed for compatibility)
      * @return Option this object (for chaining calls)
      */
-    public function setValidation(callable $function, string|callable|null $message = null): Option
+    public function setValidation(callable $function, $message = null): Option
     {
         $this->argument->setValidation($function, $message);
         return $this;

--- a/src/Option.php
+++ b/src/Option.php
@@ -32,7 +32,7 @@ class Option implements Describable
      *                        or digit) or null for short-only options
      * @param string   $mode  Whether the option can/must have an argument (optional, defaults to no argument)
      */
-    public function __construct(?string $short, string $long = null, string $mode = GetOpt::NO_ARGUMENT)
+    public function __construct(?string $short, ?string $long = null, string $mode = GetOpt::NO_ARGUMENT)
     {
         if (!$short && !$long) {
             throw new \InvalidArgumentException("The short and long name may not both be empty");
@@ -57,7 +57,7 @@ class Option implements Describable
      * @param string   $mode
      * @return static
      */
-    public static function create(?string $short, string $long = null, string $mode = GetOpt::NO_ARGUMENT): Option
+    public static function create(?string $short, ?string $long = null, string $mode = GetOpt::NO_ARGUMENT): Option
     {
         return new static($short, $long, $mode);
     }
@@ -98,10 +98,10 @@ class Option implements Describable
      * Defines a validation function for the option.
      *
      * @param callable        $function
-     * @param string|callable $message
+     * @param string|callable|null $message
      * @return Option this object (for chaining calls)
      */
-    public function setValidation(callable $function, $message = null): Option
+    public function setValidation(callable $function, string|callable|null $message = null): Option
     {
         $this->argument->setValidation($function, $message);
         return $this;
@@ -239,7 +239,7 @@ class Option implements Describable
      * @param mixed $value
      * @return $this
      */
-    public function setValue($value = null): Option
+    public function setValue(mixed $value = null): Option
     {
         if ($value === null) {
             if (in_array($this->mode, [ GetOpt::REQUIRED_ARGUMENT, GetOpt::MULTIPLE_ARGUMENT ])) {


### PR DESCRIPTION
In php8.4, Some types declarations cause `Implicitly marking parameter $long as nullable is deprecated` errors. This PR fix it and allow php8.4 package usage. 