### PR TITLE
Support Command aliases (eg. shortnames)

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -15,6 +15,9 @@ class Command implements CommandInterface
     /** @var string */
     protected $name;
 
+    /** @var array */
+    protected $aliases = [];
+
     /** @var string */
     protected $shortDescription;
 
@@ -71,6 +74,16 @@ class Command implements CommandInterface
     }
 
     /**
+     * @param array $aliases
+     * @return $this
+     */
+    public function setAliases($aliases)
+    {
+        $this->aliases = (array) $aliases;
+        return $this;
+    }
+
+    /**
      * @param mixed $handler
      * @return $this
      * @codeCoverageIgnore trivial
@@ -113,6 +126,14 @@ class Command implements CommandInterface
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAliases()
+    {
+        return $this->aliases;
     }
 
     /**

--- a/src/GetOpt.php
+++ b/src/GetOpt.php
@@ -50,6 +50,9 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
     /** @var CommandInterface[] */
     protected $commands = [];
 
+    /** @var array */
+    protected $aliases = [];
+
     /** The command that is executed determined by process
      * @var CommandInterface */
     protected $command;
@@ -272,7 +275,11 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
                 throw new \InvalidArgumentException('$command has conflicting options');
             }
         }
-        $this->commands[$command->getName()] = $command;
+        $name = $command->getName();
+        $this->commands[$name] = $command;
+        foreach ((array) $command->getAliases() as $alias) {
+            $this->aliases[$alias] = $name;
+        }
         return $this;
     }
 
@@ -285,6 +292,7 @@ class GetOpt implements \Countable, \ArrayAccess, \IteratorAggregate
     public function getCommand($name = null): ?CommandInterface
     {
         if ($name !== null) {
+            $name = isset($this->aliases[$name]) ? $this->aliases[$name] : $name;
             return isset($this->commands[$name]) ? $this->commands[$name] : null;
         }
 

--- a/src/Help.php
+++ b/src/Help.php
@@ -249,13 +249,22 @@ class Help implements HelpInterface
                 $nameWidth = strlen($command->getName());
             }
 
+            $aliasesLine = $command->getAliases()
+                ? $this->renderAliasLine($command->getAliases())
+                : '';
+
             $data[] = [
                 $command->getName(),
-                $command->getShortDescription()
+                $command->getShortDescription() . $aliasesLine
             ];
         }
 
         return $this->getText('commands-title') . $this->renderColumns($nameWidth, $data) . PHP_EOL;
+    }
+
+    protected function renderAliasLine(array $aliases): string
+    {
+        return ' ' . $this->surround('alias: ' . implode(', ', $aliases), $this->texts['optional']);
     }
 
     protected function renderUsageCommand(): string

--- a/test/GetoptTest.php
+++ b/test/GetoptTest.php
@@ -315,6 +315,22 @@ class GetoptTest extends TestCase
     }
 
     /** @test */
+    public function getCommandByAlias(): void
+    {
+        $cmd1 = new Command('help', 'var_dump');
+        $cmd1->setAliases(['h']);
+        $cmd2 = new Command('test', 'var_dump');
+        $cmd2->setAliases(['t']);
+        $getopt = new GetOpt();
+
+        $getopt->addCOmmands([ $cmd1, $cmd2 ]);
+
+        self::assertSame($cmd1, $getopt->getCommand('h'));
+        self::assertSame($cmd2, $getopt->getCommand('t'));
+        self::assertNull($getopt->getCommand());
+    }
+
+    /** @test */
     public function setHelpLangToDe(): void
     {
         $getopt = new GetOpt();


### PR DESCRIPTION
Adds ability to register aliases for commands. I like to use longer, descriptive proper names with convenient shortcuts.


```
$ ./bin/user --help
Usage: ./bin/user <command> [options] [operands]

Options:
  --version      Show version information and quit
  -?, --help     Show this help and quit
  -v, --verbose  Increase verbosity

Commands:
  register  Register a user [alias: reg, init]
  password  Set or reset a users password [alias: passwd, pw]
  list      List users [alias: l, ls]


$ ./bin/user list
[... list command output]

$ ./bin/user ls
[... list command output]
```
